### PR TITLE
Move the jarkata.* based protocols and testenrichers to new repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Parent -->
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>41</version>
+        <relativePath />
+    </parent>
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Artifact Configuration -->
+    <groupId>org.jboss.arquillian.jakarta</groupId>
+    <artifactId>arquillian-parent-jakarta</artifactId>
+    <version>1.8.1.Final-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Arquillian Jakarta Parent</name>
+    <description>Jakarta protocols and testenrichers for the Arquillian Project</description>
+
+    <scm>
+        <connection>scm:git:git://git@github.com:arquillian/arquillian-jakarta.git</connection>
+        <developerConnection>scm:git:ssh://github.com/arquillian/arquillian-jakarta.git</developerConnection>
+        <url>git://github.com/arquillian/arquillian-jakarta.git</url>
+        <tag>1.8.0.Final</tag>
+    </scm>
+
+    <!-- Properties -->
+    <properties>
+        <!-- Versioning -->
+        <version.arquillian_core>1.7.1.Final</version.arquillian_core>
+
+        <version.shrinkwrap>3.2.1</version.shrinkwrap>
+
+        <version.glassfish.el>2.2</version.glassfish.el>
+        <version.h2>2.2.224</version.h2>
+        <version.slf4j>2.0.7</version.slf4j>
+
+        <!-- override from parent -->
+        <maven.compiler.release>11</maven.compiler.release>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.10.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap.resolver</groupId>
+                <artifactId>shrinkwrap-resolver-bom</artifactId>
+                <version>${version.shrinkwrap}</version>
+                <scope>test</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap.resolver</groupId>
+                <artifactId>shrinkwrap-resolver-depchain</artifactId>
+                <version>${version.shrinkwrap}</version>
+                <type>pom</type>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${version.arquillian_core}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-build</artifactId>
+                <version>${version.arquillian_core}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.weld.servlet</groupId>
+                <artifactId>weld-servlet-core</artifactId>
+                <version>${version.weld}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.web</groupId>
+                <artifactId>el-impl</artifactId>
+                <version>${version.glassfish.el}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${version.h2}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${version.slf4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${version.slf4j}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>2.2</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>2.1.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <pushChanges>false</pushChanges>
+                    <localCheckout>true</localCheckout>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>build-server</id>
+            <build>
+                <plugins>
+                    <!--
+                        surefire default forks the JVM for testing, so we need to pass on the maven.repo.local variable so the MavenResovler used in
+                        the test cases can read from the same local repo.
+                     -->
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <maven.repo.local>${maven.repo.local}</maven.repo.local>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <modules>
+        <module>protocols</module>
+        <module>testenrichers</module>
+    </modules>
+
+    <distributionManagement>
+        <repository>
+            <id>${jboss.releases.repo.id}</id>
+            <name>JBoss Releases Repository</name>
+            <url>${jboss.releases.repo.url}</url>
+        </repository>
+        <snapshotRepository>
+            <id>${jboss.snapshots.repo.id}</id>
+            <name>JBoss Snapshots Repository</name>
+            <url>${jboss.snapshots.repo.url}</url>
+        </snapshotRepository>
+    </distributionManagement>
+</project>

--- a/protocols/pom.xml
+++ b/protocols/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- vi:ts=2:sw=2:expandtab: -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <!-- Parent -->
+  <parent>
+    <groupId>org.jboss.arquillian.jakarta</groupId>
+    <artifactId>arquillian-parent-jakarta</artifactId>
+    <version>1.8.1.Final-SNAPSHOT</version>
+  </parent>
+
+  <!-- Model Information -->
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Artifact Information -->
+  <groupId>org.jboss.arquillian.protocol</groupId>
+  <artifactId>arquillian-protocol-parent</artifactId>
+  <packaging>pom</packaging>
+  <name>Arquillian Protocol Aggregator</name>
+  <description>Arquillian Protocol Aggregator</description>
+
+  <modules>
+    <module>servlet-jakarta</module>
+    <module>rest-jakarta</module>
+  </modules>
+</project>

--- a/protocols/rest-jakarta/README.adoc
+++ b/protocols/rest-jakarta/README.adoc
@@ -1,0 +1,10 @@
+= Jakarta EE 9 REST 3 API Protocol
+
+This is a port of the servlet jakarta protocol handler for communicating using a REST application following the Jakarta RESTful Web Services 3.x spec.
+
+== Issues
+This relies on a release of org.eclipse.jetty:jetty-server that supports the Jakarta Servlet 5.x spec. The current
+11.0.0-alpha0 release in turn requires Java 11, so this module required Java 8 to compile the module artifact, but
+it requires Java 11 to build and run the modules tests.
+
+https://github.com/eclipse/jetty.project

--- a/protocols/rest-jakarta/pom.xml
+++ b/protocols/rest-jakarta/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <!-- Parent -->
+  <parent>
+    <groupId>org.jboss.arquillian.jakarta</groupId>
+    <artifactId>arquillian-parent-jakarta</artifactId>
+    <version>1.8.1.Final-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <!-- Model Version -->
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Artifact Configuration -->
+  <groupId>org.jboss.arquillian.protocol</groupId>
+  <artifactId>arquillian-protocol-rest-jakarta</artifactId>
+  <name>Arquillian Protocol REST 3.x</name>
+  <description>Protocol handler for communicating using REST following the Jakarta RESTful Web Services 3.x spec and jakarta.ws.rs.* apis
+  </description>
+
+  <!-- Properties -->
+  <properties>
+    <!-- Versioning -->
+    <version.jetty_jetty>11.0.14</version.jetty_jetty>
+    <version.resteasy>6.2.6.Final</version.resteasy>
+    <version.restfulws-api>3.1.0</version.restfulws-api>
+  </properties>
+
+  <!-- Dependencies -->
+  <dependencies>
+
+    <!-- org.jboss.arquillian -->
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-impl-base</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.protocol</groupId>
+      <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+      <artifactId>shrinkwrap-descriptors-spi</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- restfulws api -->
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>${version.restfulws-api}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.shrinkwrap</groupId>
+      <artifactId>shrinkwrap-impl-base</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>${version.jetty_jetty}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>${version.jetty_jetty}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-servlet-initializer</artifactId>
+      <version>${version.resteasy}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-core</artifactId>
+      <version>${version.resteasy}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <!-- The test -->
+  <profiles>
+    <!-- Need to skip test compilation for Java8 and earlier since jetty-server is compiled under Java11 -->
+    <profile>
+      <id>jdk8</id>
+      <activation>
+        <jdk>[,9)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-testCompile</id>
+                <phase>test-compile</phase>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk11</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <properties>
+        <!-- The tests need to be build and run the Java 11 due to the fact that jetty 11.x which
+        supports the Java EE 9 apis requires Java 11
+        -->
+        <maven.compiler.testSource>11</maven.compiler.testSource>
+        <maven.compiler.testTarget>11</maven.compiler.testTarget>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/REST3Extension.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/REST3Extension.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+public class REST3Extension implements LoadableExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(Protocol.class, RESTProtocol.class);
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTDeploymentAppender.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTDeploymentAppender.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+import org.jboss.arquillian.protocol.rest.runner.RESTRemoteExtension;
+
+public class RESTDeploymentAppender implements AuxiliaryArchiveAppender {
+
+    @Override
+    public JavaArchive createAuxiliaryArchive() {
+        // Load based on package to avoid ClassNotFoundException on Application when loading RESTTestRunner
+        return ShrinkWrap.create(JavaArchive.class, "arquillian-jakarta-rest-protocol.jar")
+            .addPackage(RESTRemoteExtension.class.getPackage()) // rest.runner
+            .addAsServiceProvider(RemoteLoadableExtension.class, RESTRemoteExtension.class);
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTDeploymentPackager.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTDeploymentPackager.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+import org.jboss.arquillian.container.spi.client.deployment.Validate;
+import org.jboss.arquillian.container.test.spi.TestDeployment;
+import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentPackager;
+import org.jboss.arquillian.container.test.spi.client.deployment.ProtocolArchiveProcessor;
+import org.jboss.arquillian.protocol.servlet5.Processor;
+import org.jboss.arquillian.protocol.servlet5.ServletUtil;
+import org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.application.ApplicationDescriptor;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.Filters;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+
+import static org.jboss.arquillian.protocol.servlet5.ServletUtil.APPLICATION_XML_PATH;
+
+/**
+ * Same as the Servlet DeploymentPackager except uses the RESTDeploymentAppender instead.
+ */
+public class RESTDeploymentPackager implements DeploymentPackager {
+
+    @Override
+    public Archive<?> generateDeployment(TestDeployment testDeployment, Collection<ProtocolArchiveProcessor> processors) {
+        JavaArchive protocol = new RESTDeploymentAppender().createAuxiliaryArchive();
+
+        Archive<?> applicationArchive = testDeployment.getApplicationArchive();
+        Collection<Archive<?>> auxiliaryArchives = testDeployment.getAuxiliaryArchives();
+
+        Processor processor = new Processor(testDeployment, processors);
+
+        if (Validate.isArchiveOfType(EnterpriseArchive.class, applicationArchive)) {
+            return handleArchive(applicationArchive.as(EnterpriseArchive.class), auxiliaryArchives, protocol, processor,
+                testDeployment);
+        }
+
+        if (Validate.isArchiveOfType(WebArchive.class, applicationArchive)) {
+            return handleArchive(applicationArchive.as(WebArchive.class), auxiliaryArchives, protocol, processor);
+        }
+
+        if (Validate.isArchiveOfType(JavaArchive.class, applicationArchive)) {
+            return handleArchive(applicationArchive.as(JavaArchive.class), auxiliaryArchives, protocol, processor);
+        }
+
+        throw new IllegalArgumentException(RESTDeploymentPackager.class.getName() +
+            " can not handle archive of type " + applicationArchive.getClass().getName());
+    }
+
+    private Archive<?> handleArchive(WebArchive applicationArchive, Collection<Archive<?>> auxiliaryArchives,
+        JavaArchive protocol, Processor processor) {
+        applicationArchive
+            .addAsLibraries(
+                auxiliaryArchives.toArray(new Archive<?>[0]));
+
+        // Can be null when reusing logic in EAR packaging
+        if (protocol != null) {
+            applicationArchive.addAsLibrary(protocol);
+        }
+        processor.process(applicationArchive);
+        return applicationArchive;
+    }
+
+    private Archive<?> handleArchive(JavaArchive applicationArchive, Collection<Archive<?>> auxiliaryArchives,
+        JavaArchive protocol, Processor processor) {
+        return handleArchive(
+            ShrinkWrap.create(WebArchive.class, "test-" + UUID.randomUUID().toString() + ".war")
+                .addAsLibrary(applicationArchive),
+            auxiliaryArchives,
+            protocol,
+            processor);
+    }
+
+    private Archive<?> handleArchive(EnterpriseArchive applicationArchive, Collection<Archive<?>> auxiliaryArchives,
+        JavaArchive protocol, Processor processor, TestDeployment testDeployment) {
+        Map<ArchivePath, Node> applicationArchiveWars = applicationArchive.getContent(Filters.include(".*\\.war"));
+        if (applicationArchiveWars.size() == 1) {
+            ArchivePath warPath = applicationArchiveWars.keySet().iterator().next();
+            try {
+                handleArchive(
+                    applicationArchive.getAsType(WebArchive.class, warPath),
+                    new ArrayList<Archive<?>>(),
+                    // reuse the War handling, but Auxiliary Archives should be added to the EAR, not the WAR
+                    protocol,
+                    processor);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Can not manipulate war's that are not of type " + WebArchive.class,
+                    e);
+            }
+        } else if (applicationArchiveWars.size() > 1) {
+            Archive<?> archiveToTest = testDeployment.getArchiveForEnrichment();
+            if (archiveToTest == null) {
+                throw new UnsupportedOperationException("Multiple WebArchives found in "
+                    + applicationArchive.getName()
+                    + ". Can not determine which to enrich");
+            } else if (!archiveToTest.getName().endsWith(".war")) {
+                //TODO: Removed throwing an exception when EJB modules are supported as well
+                throw new UnsupportedOperationException("Archive to test is not a WebArchive!");
+            } else {
+                handleArchive(
+                    archiveToTest.as(WebArchive.class),
+                    new ArrayList<Archive<?>>(),
+                    // reuse the War handling, but Auxiliary Archives should be added to the EAR, not the WAR
+                    protocol,
+                    processor);
+            }
+        } else {
+            // reuse handle(JavaArchive, ..) logic
+            Archive<?> wrappedWar = handleArchive(protocol, new ArrayList<Archive<?>>(), null, processor);
+            applicationArchive
+                .addAsModule(wrappedWar);
+
+            if (applicationArchive.contains(APPLICATION_XML_PATH)) {
+                ApplicationDescriptor applicationXml = Descriptors.importAs(ApplicationDescriptor.class).fromStream(
+                    applicationArchive.get(APPLICATION_XML_PATH).getAsset().openStream());
+
+                applicationXml.webModule(wrappedWar.getName(), ServletUtil.calculateContextRoot(wrappedWar.getName()));
+
+                // SHRINKWRAP-187, to eager on not allowing overrides, delete it first
+                applicationArchive.delete(APPLICATION_XML_PATH);
+                applicationArchive.setApplicationXML(
+                    new StringAsset(applicationXml.exportAsString()));
+            }
+        }
+
+        applicationArchive.addAsLibraries(
+            auxiliaryArchives.toArray(new Archive<?>[0]));
+
+        return applicationArchive;
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTMethodExecutor.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTMethodExecutor.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.util.Collection;
+import java.util.Timer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.test.spi.command.CommandCallback;
+import org.jboss.arquillian.protocol.servlet5.ServletMethodExecutor;
+import org.jboss.arquillian.protocol.servlet5.ServletProtocolConfiguration;
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+import org.jboss.arquillian.test.spi.TestResult;
+
+public class RESTMethodExecutor extends ServletMethodExecutor {
+    public static final String ARQUILLIAN_REST_NAME = "ArquillianRESTRunnerEE9";
+    public static final String ARQUILLIAN_REST_MAPPING = "/" + ARQUILLIAN_REST_NAME;
+
+    public RESTMethodExecutor(ServletProtocolConfiguration config, Collection<HTTPContext> contexts,
+            CommandCallback callback) {
+        if (config == null) {
+            throw new IllegalArgumentException("ServletProtocolConfiguration must be specified");
+        }
+        if (contexts == null || contexts.size() == 0) {
+            throw new IllegalArgumentException("HTTPContext must be specified");
+        }
+        if (callback == null) {
+            throw new IllegalArgumentException("Callback must be specified");
+        }
+        this.config = config;
+        this.uriHandler = new RESTURIHandler(config, contexts);
+        this.callback = callback;
+    }
+
+    @Override
+    public TestResult invoke(final TestMethodExecutor testMethodExecutor) {
+        if (testMethodExecutor == null) {
+            throw new IllegalArgumentException("TestMethodExecutor must be specified");
+        }
+
+        URI targetBaseURI = uriHandler.locateTestServlet(testMethodExecutor.getMethod());
+
+        Class<?> testClass = testMethodExecutor.getInstance().getClass();
+
+        Timer eventTimer = null;
+        Lock timerLock = new ReentrantLock();
+        AtomicBoolean isCanceled = new AtomicBoolean();
+        try {
+            String urlEncodedMethodName = URLEncoder.encode(testMethodExecutor.getMethodName(), "UTF-8");
+            final String url = targetBaseURI.toASCIIString() + ARQUILLIAN_REST_MAPPING
+                + "?outputMode=serializedObject&className=" + testClass.getName() + "&methodName="
+                + urlEncodedMethodName;
+
+            final String eventUrl = targetBaseURI.toASCIIString() + ARQUILLIAN_REST_MAPPING
+                + "?outputMode=serializedObject&className=" + testClass.getName() + "&methodName="
+                + urlEncodedMethodName + "&cmd=event";
+
+            eventTimer = createCommandServicePullTimer(eventUrl, timerLock, isCanceled);
+            return executeWithRetry(url, TestResult.class);
+        } catch (Exception e) {
+            throw new IllegalStateException("Error launching test " + testClass.getName() + " "
+                + testMethodExecutor.getMethod(), e);
+        } finally {
+            if (eventTimer != null) {
+                eventTimer.cancel();
+                timerLock.lock();
+                try {
+                    isCanceled.set(true);
+                } finally {
+                    timerLock.unlock();
+                }
+            }
+        }
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTProtocol.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTProtocol.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.util.Collection;
+
+import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentPackager;
+import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
+import org.jboss.arquillian.container.test.spi.command.CommandCallback;
+import org.jboss.arquillian.protocol.servlet5.ServletProtocolConfiguration;
+
+public class RESTProtocol implements Protocol<ServletProtocolConfiguration> {
+    public static final String PROTOCOL_NAME = "REST 3.0";
+
+    @Override
+    public ProtocolDescription getDescription() {
+        return new ProtocolDescription(PROTOCOL_NAME);
+    }
+
+    @Override
+    public RESTMethodExecutor getExecutor(ServletProtocolConfiguration protocolConfiguration, ProtocolMetaData metaData,
+            CommandCallback callback) {
+        Collection<HTTPContext> contexts = metaData.getContexts(HTTPContext.class);
+        if (contexts.size() == 0) {
+            throw new IllegalArgumentException(
+                "No " + HTTPContext.class.getName() + " found in " + ProtocolMetaData.class.getName() + ". " +
+                    "REST protocol can not be used");
+        }
+        return new RESTMethodExecutor(protocolConfiguration, contexts, callback);
+    }
+
+    @Override
+    public DeploymentPackager getPackager() {
+        return new RESTDeploymentPackager();
+    }
+
+    @Override
+    public Class<ServletProtocolConfiguration> getProtocolConfigurationClass() {
+        return ServletProtocolConfiguration.class;
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTURIHandler.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/RESTURIHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.Collection;
+
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.protocol.servlet5.ServletProtocolConfiguration;
+import org.jboss.arquillian.protocol.servlet5.ServletURIHandler;
+import org.jboss.arquillian.protocol.servlet5.ServletUtil;
+
+public class RESTURIHandler extends ServletURIHandler {
+
+    private ServletProtocolConfiguration config;
+    public RESTURIHandler(ServletProtocolConfiguration config, Collection<HTTPContext> contexts) {
+        super(config, contexts);
+        this.config = config;
+    }
+
+    public URI locateTestServlet(Method method) {
+        HTTPContext context = locateHTTPContext(method);
+        return ServletUtil.determineBaseURI(
+            config,
+            context,
+            RESTMethodExecutor.ARQUILLIAN_REST_NAME);
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTCommandService.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTCommandService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.runner;
+
+import org.jboss.arquillian.container.test.spi.command.Command;
+import org.jboss.arquillian.container.test.spi.command.CommandService;
+
+public class RESTCommandService implements CommandService {
+    private static long TIMEOUT = 30000;
+
+    @SuppressWarnings("unchecked")
+    public <T> T execute(Command<T> command) {
+        String currentId = RESTTestRunner.currentCall.get();
+        RESTTestRunner.events.put(currentId, command);
+
+        long timeoutTime = System.currentTimeMillis() + TIMEOUT;
+        while (timeoutTime > System.currentTimeMillis()) {
+            Command<?> newCommand = RESTTestRunner.events.get(currentId);
+            if (newCommand != null) {
+                if (newCommand.getThrowable() != null) {
+                    throw new RuntimeException(newCommand.getThrowable());
+                }
+                if (newCommand.getResult() != null) {
+                    return (T) newCommand.getResult();
+                }
+            }
+            try {
+                Thread.sleep(100);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        throw new RuntimeException("No command response within timeout of " + TIMEOUT + " ms.");
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTProtocolApplication.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTProtocolApplication.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.runner;
+
+import java.util.Collections;
+import java.util.Set;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/ArquillianRESTRunnerEE9")
+public class RESTProtocolApplication extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        return Collections.singleton(RESTTestRunner.class);
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTRemoteExtension.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTRemoteExtension.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.runner;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.container.test.spi.command.CommandService;
+
+public class RESTRemoteExtension implements RemoteLoadableExtension {
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(CommandService.class, RESTCommandService.class);
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTTestRunner.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/RESTTestRunner.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * identified by the Git commit log. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.runner;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jboss.arquillian.container.test.spi.TestRunner;
+import org.jboss.arquillian.container.test.spi.command.Command;
+import org.jboss.arquillian.container.test.spi.util.TestRunners;
+import org.jboss.arquillian.test.spi.TestResult;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.ResponseBuilder;
+import jakarta.ws.rs.core.Response.Status;
+
+/**
+ * RESTTestRunner
+ * <p>
+ * The server side executor for the REST protocol impl.
+ * <p>
+ * Supports multiple output modes ("outputmode"):
+ * - html
+ * - serializedObject
+ * 
+ * A conversion of the ServletTestRunner to use RESTful Web Services instead.
+ */
+@Path("")
+public class RESTTestRunner {
+    public static final String PARA_METHOD_NAME = "methodName";
+    public static final String PARA_CLASS_NAME = "className";
+    public static final String PARA_OUTPUT_MODE = "outputMode";
+    public static final String PARA_CMD_NAME = "cmd";
+    public static final String OUTPUT_MODE_SERIALIZED = "serializedObject";
+    public static final String OUTPUT_MODE_HTML = "html";
+    public static final String CMD_NAME_TEST = "test";
+    public static final String CMD_NAME_EVENT = "event";
+    static ConcurrentHashMap<String, Command<?>> events = new ConcurrentHashMap<>();
+    static ThreadLocal<String> currentCall = new ThreadLocal<>();
+
+    @POST
+    public Response doPost(@QueryParam(PARA_OUTPUT_MODE) String outputMode, @QueryParam(PARA_CLASS_NAME) String className,
+            @QueryParam(PARA_METHOD_NAME) String methodName, @QueryParam(PARA_CMD_NAME) String cmd, byte[] cmdObject) throws WebApplicationException, IOException {
+        return execute(outputMode, className, methodName, cmd, cmdObject);
+    }
+
+    @GET
+    public Response doGet(@QueryParam(PARA_OUTPUT_MODE) String outputMode, @QueryParam(PARA_CLASS_NAME) String className,
+            @QueryParam(PARA_METHOD_NAME) String methodName, @QueryParam(PARA_CMD_NAME) String cmd) throws WebApplicationException, IOException {
+        return execute(outputMode, className, methodName, cmd, null);
+    }
+
+    protected Response execute(String outputMode, String className, String methodName, String cmd, byte[] cmdObject)
+        throws WebApplicationException, IOException {
+        if (outputMode == null) {
+            outputMode = OUTPUT_MODE_HTML;
+        }
+        if (cmd == null) {
+            cmd = CMD_NAME_TEST;
+        }
+        ResponseBuilder response = Response.ok();
+        try {
+
+            if (className == null) {
+                throw new IllegalArgumentException(PARA_CLASS_NAME + " must be specified");
+            }
+            if (methodName == null) {
+                throw new IllegalArgumentException(PARA_METHOD_NAME + " must be specified");
+            }
+
+            currentCall.set(className + methodName);
+
+            if (CMD_NAME_TEST.equals(cmd)) {
+                executeTest(response, outputMode, className, methodName);
+            } else if (CMD_NAME_EVENT.equals(cmd)) {
+                executeEvent(cmdObject, response, className, methodName);
+            } else {
+                throw new RuntimeException("Unknown value for parameter" + PARA_CMD_NAME + ": " + cmd);
+            }
+        } catch (Exception e) {
+            if (OUTPUT_MODE_SERIALIZED.equalsIgnoreCase(outputMode)) {
+                writeObject(createFailedResult(e), response);
+            } else {
+                response.status(Status.INTERNAL_SERVER_ERROR.getStatusCode(), e.getMessage());
+            }
+        } finally {
+            currentCall.remove();
+        }
+        return response.build();
+    }
+
+    public void executeTest(ResponseBuilder response, String outputMode, String className, String methodName)
+        throws ClassNotFoundException, IOException {
+        Class<?> testClass = SecurityActions.getThreadContextClassLoader().loadClass(className);
+        TestRunner runner = TestRunners.getTestRunner();
+        TestResult testResult = runner.execute(testClass, methodName);
+        if (OUTPUT_MODE_SERIALIZED.equalsIgnoreCase(outputMode)) {
+            writeObject(testResult, response);
+        } else {
+            // TODO: implement a html view of the result
+            response.type(MediaType.TEXT_HTML_TYPE);
+            response.status(Status.OK);
+            StringBuilder buffer = new StringBuilder();
+            buffer.append("<html>\n");
+            buffer.append("<head><title>TCK Report</title></head>\n");
+            buffer.append("<body>\n");
+            buffer.append("<h2>Configuration</h2>\n");
+            buffer.append("<table>\n");
+            buffer.append("<tr>\n");
+            buffer.append("<td><b>Method</b></td><td><b>Status</b></td>\n");
+            buffer.append("</tr>\n");
+
+            buffer.append("</table>\n");
+            buffer.append("<h2>Tests</h2>\n");
+            buffer.append("<table>\n");
+            buffer.append("<tr>\n");
+            buffer.append("<td><b>Method</b></td><td><b>Status</b></td>\n");
+            buffer.append("</tr>\n");
+
+            buffer.append("</table>\n");
+            buffer.append("</body>\n");
+            response.entity(buffer.toString());
+        }
+    }
+
+    public void executeEvent(byte[] cmdObject, ResponseBuilder response, String className,
+        String methodName)
+        throws ClassNotFoundException, IOException {
+        String eventKey = className + methodName;
+
+        if (cmdObject != null && cmdObject.length > 0) {
+            response.status(Status.NO_CONTENT);
+            ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(cmdObject));
+            Command<?> result = (Command<?>) input.readObject();
+            input.close();
+
+            events.put(eventKey, result);
+        } else {
+            if (events.containsKey(eventKey) && events.get(eventKey).getResult() == null) {
+                response.status(Status.OK);
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ObjectOutputStream output = new ObjectOutputStream(baos);
+                output.writeObject(events.remove(eventKey));
+                output.flush();
+                response.type(MediaType.APPLICATION_OCTET_STREAM_TYPE);
+                response.entity(baos.toByteArray());
+                output.close();
+            } else {
+                response.status(Status.NO_CONTENT);
+            }
+        }
+    }
+
+    private void writeObject(Object object, ResponseBuilder response) {
+        try {
+            response.status(Status.OK);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(object);
+            oos.flush();
+            response.type(MediaType.APPLICATION_OCTET_STREAM_TYPE);
+            response.entity(baos.toByteArray());
+            oos.close();
+        } catch (Exception e) {
+            try {
+                response.status(Status.INTERNAL_SERVER_ERROR.getStatusCode(), e.getMessage());
+            } catch (Exception e2) {
+                throw new RuntimeException("Could not write to output", e2);
+            }
+        }
+    }
+
+    private TestResult createFailedResult(Throwable throwable) {
+        return TestResult.failed(throwable);
+    }
+}

--- a/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/SecurityActions.java
+++ b/protocols/rest-jakarta/src/main/java/org/jboss/arquillian/protocol/rest/runner/SecurityActions.java
@@ -1,0 +1,337 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.runner;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A set of privileged actions that are not to leak out
+ * of this package
+ *
+ * Copy of the servlet SecurityActions since it is package protected
+ */
+final class SecurityActions {
+
+    //-------------------------------------------------------------------------------||
+    // Constructor ------------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * No instantiation
+     */
+    private SecurityActions() {
+        throw new UnsupportedOperationException("No instantiation");
+    }
+
+    //-------------------------------------------------------------------------------||
+    // Utility Methods --------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * Obtains the Thread Context ClassLoader
+     */
+    static ClassLoader getThreadContextClassLoader() {
+        return AccessController.doPrivileged(GetTcclAction.INSTANCE);
+    }
+
+    static boolean isClassPresent(String name) {
+        try {
+            loadClass(name);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    static Class<?> loadClass(String className) {
+        try {
+            return Class.forName(className, true, getThreadContextClassLoader());
+        } catch (ClassNotFoundException e) {
+            try {
+                return Class.forName(className, true, SecurityActions.class.getClassLoader());
+            } catch (ClassNotFoundException e2) {
+                throw new RuntimeException("Could not load class " + className, e2);
+            }
+        }
+    }
+
+    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments,
+        final Class<T> expectedType) {
+        @SuppressWarnings("unchecked")
+        Class<T> implClass = (Class<T>) loadClass(className);
+        if (!expectedType.isAssignableFrom(implClass)) {
+            throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+        }
+        return newInstance(implClass, argumentTypes, arguments);
+    }
+
+    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments,
+        final Class<T> expectedType, ClassLoader classLoader) {
+        Class<?> clazz = null;
+        try {
+            clazz = Class.forName(className, false, classLoader);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not load class " + className, e);
+        }
+        Object obj = newInstance(clazz, argumentTypes, arguments);
+        try {
+            return expectedType.cast(obj);
+        } catch (Exception e) {
+            throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType, e);
+        }
+    }
+
+    /**
+     * Create a new instance by finding a constructor that matches the argumentTypes signature
+     * using the arguments for instantiation.
+     *
+     * @param implClass
+     *     Full classname of class to create
+     * @param argumentTypes
+     *     The constructor argument types
+     * @param arguments
+     *     The constructor arguments
+     *
+     * @return a new instance
+     *
+     * @throws IllegalArgumentException
+     *     if className, argumentTypes, or arguments are null
+     * @throws RuntimeException
+     *     if any exceptions during creation
+     * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+     * @author <a href="mailto:andrew.rubinger@jboss.org">ALR</a>
+     */
+    static <T> T newInstance(final Class<T> implClass, final Class<?>[] argumentTypes, final Object[] arguments) {
+        if (implClass == null) {
+            throw new IllegalArgumentException("ImplClass must be specified");
+        }
+        if (argumentTypes == null) {
+            throw new IllegalArgumentException("ArgumentTypes must be specified. Use empty array if no arguments");
+        }
+        if (arguments == null) {
+            throw new IllegalArgumentException("Arguments must be specified. Use empty array if no arguments");
+        }
+        final T obj;
+        try {
+            Constructor<T> constructor = getConstructor(implClass, argumentTypes);
+            if (!constructor.isAccessible()) {
+                constructor.setAccessible(true);
+            }
+            obj = constructor.newInstance(arguments);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create new instance of " + implClass, e);
+        }
+
+        return obj;
+    }
+
+    /**
+     * Obtains the Constructor specified from the given Class and argument types
+     *
+     * @throws NoSuchMethodException
+     */
+    static <T> Constructor<T> getConstructor(final Class<T> clazz, final Class<?>... argumentTypes)
+        throws NoSuchMethodException {
+        try {
+            return AccessController.doPrivileged(new PrivilegedExceptionAction<Constructor<T>>() {
+                public Constructor<T> run() throws NoSuchMethodException {
+                    return clazz.getDeclaredConstructor(argumentTypes);
+                }
+            });
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof NoSuchMethodException) {
+                throw (NoSuchMethodException) t;
+            } else {
+                // No other checked Exception thrown by Class.getConstructor
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    /**
+     * Set a single Field value
+     *
+     * @param target
+     *     The object to set it on
+     * @param fieldName
+     *     The field name
+     * @param value
+     *     The new value
+     */
+    public static void setFieldValue(final Class<?> source, final Object target, final String fieldName,
+        final Object value) throws NoSuchFieldException {
+        try {
+            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
+                @Override
+                public Void run() throws Exception {
+                    Field field = source.getDeclaredField(fieldName);
+                    if (!field.isAccessible()) {
+                        field.setAccessible(true);
+                    }
+                    field.set(target, value);
+                    return null;
+                }
+            });
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof NoSuchFieldException) {
+                throw (NoSuchFieldException) t;
+            } else {
+                // No other checked Exception thrown by Class.getConstructor
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    public static List<Field> getFieldsWithAnnotation(final Class<?> source,
+        final Class<? extends Annotation> annotationClass) {
+        List<Field> declaredAccessableFields = AccessController.doPrivileged(new PrivilegedAction<List<Field>>() {
+            public List<Field> run() {
+                List<Field> foundFields = new ArrayList<Field>();
+                Class<?> nextSource = source;
+                while (nextSource != Object.class) {
+                    for (Field field : nextSource.getDeclaredFields()) {
+                        if (field.isAnnotationPresent(annotationClass)) {
+                            if (!field.isAccessible()) {
+                                field.setAccessible(true);
+                            }
+                            foundFields.add(field);
+                        }
+                    }
+                    nextSource = nextSource.getSuperclass();
+                }
+                return foundFields;
+            }
+        });
+        return declaredAccessableFields;
+    }
+
+    public static List<Method> getMethodsWithAnnotation(final Class<?> source,
+        final Class<? extends Annotation> annotationClass) {
+        List<Method> declaredAccessableMethods = AccessController.doPrivileged(new PrivilegedAction<List<Method>>() {
+            public List<Method> run() {
+                List<Method> foundMethods = new ArrayList<Method>();
+                Class<?> nextSource = source;
+                while (nextSource != Object.class) {
+                    for (Method method : filterBridgeMethods(nextSource.getDeclaredMethods())) {
+                        if (method.isAnnotationPresent(annotationClass)) {
+                            if (!method.isAccessible()) {
+                                method.setAccessible(true);
+                            }
+                            foundMethods.add(method);
+                        }
+                    }
+                    nextSource = nextSource.getSuperclass();
+                }
+                return foundMethods;
+            }
+        });
+        return declaredAccessableMethods;
+    }
+
+    static String getProperty(final String key) {
+        try {
+            String value = AccessController.doPrivileged(new PrivilegedExceptionAction<String>() {
+                public String run() {
+                    return System.getProperty(key);
+                }
+            });
+            return value;
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof SecurityException) {
+                throw (SecurityException) t;
+            }
+            if (t instanceof NullPointerException) {
+                throw (NullPointerException) t;
+            } else if (t instanceof IllegalArgumentException) {
+                throw (IllegalArgumentException) t;
+            } else {
+                // No other checked Exception thrown by System.getProtocolProperty
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    private static Collection<Method> filterBridgeMethods(Method... declaredMethods) {
+        final List<Method> nonBridgeMethods = new ArrayList<Method>(declaredMethods.length);
+
+        for (Method declaredMethod : declaredMethods) {
+            if (!declaredMethod.isBridge()) {
+                nonBridgeMethods.add(declaredMethod);
+            }
+        }
+
+        return nonBridgeMethods;
+    }
+
+    //-------------------------------------------------------------------------------||
+    // Inner Classes ----------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * Single instance to get the TCCL
+     */
+    private enum GetTcclAction implements PrivilegedAction<ClassLoader>
+
+    {
+        INSTANCE;
+
+        public ClassLoader run() {
+            return Thread.currentThread().getContextClassLoader();
+        }
+
+    }
+}

--- a/protocols/rest-jakarta/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/protocols/rest-jakarta/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.arquillian.protocol.rest.REST3Extension

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/AbstractServerBase.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/AbstractServerBase.java
@@ -1,0 +1,163 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.jetty.server.NetworkConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
+import org.jboss.arquillian.protocol.rest.test.MockTestRunner;
+import org.jboss.arquillian.protocol.rest.runner.RESTProtocolApplication;
+import org.jboss.arquillian.protocol.rest.runner.RESTTestRunner;
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * AbstractServerBase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class AbstractServerBase {
+    Server server;
+
+    @Before
+    public void setup() throws Exception {
+        int port = getAvailableLocalPort();
+        server = new Server(port);
+
+        ServletContextHandler root = new ServletContextHandler(server, "/arquillian-protocol", ServletContextHandler.SESSIONS);
+        ServletHolder holder = new ServletHolder(HttpServletDispatcher.class); 
+        holder.setInitParameter("jakarta.ws.rs.Application", RESTProtocolApplication.class.getName());
+        holder.setInitParameter("resteasy.servlet.mapping.prefix", RESTMethodExecutor.ARQUILLIAN_REST_MAPPING);
+		root.addServlet(holder, RESTMethodExecutor.ARQUILLIAN_REST_MAPPING);
+        server.start();
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        MockTestRunner.clear();
+        server.stop();
+    }
+
+    private int getAvailableLocalPort() throws IOException {
+        ServerSocket socket = null;
+        try {
+            socket = new ServerSocket(0);
+            return socket.getLocalPort();
+        } finally {
+            if (socket != null) {
+                socket.close();
+            }
+        }
+    }
+
+    protected Collection<HTTPContext> createContexts() {
+        List<HTTPContext> context = new ArrayList<HTTPContext>();
+        context.add(createContext());
+        return context;
+    }
+
+    protected HTTPContext createContext() {
+        URI baseURI = createBaseURL();
+        HTTPContext context = new HTTPContext(baseURI.getHost(), baseURI.getPort());
+        context.add(new Servlet(RESTMethodExecutor.ARQUILLIAN_REST_NAME, baseURI.getPath()));
+        return context;
+    }
+
+    protected URI createBaseURL() {
+        NetworkConnector conn0 = (NetworkConnector) server.getConnectors()[0];
+        return URI.create("http://localhost:" + conn0.getPort() + "/arquillian-protocol");
+    }
+
+    protected URL createURL(String outputMode, String testClass, String methodName) {
+        StringBuilder url = new StringBuilder(createBaseURL().toASCIIString() + RESTMethodExecutor.ARQUILLIAN_REST_MAPPING);
+        boolean first = true;
+        if (outputMode != null) {
+            if (first) {
+                first = false;
+                url.append("?");
+            } else {
+                url.append("&");
+            }
+            url.append(RESTTestRunner.PARA_OUTPUT_MODE).append("=").append(outputMode);
+        }
+        if (testClass != null) {
+            if (first) {
+                first = false;
+                url.append("?");
+            } else {
+                url.append("&");
+            }
+            url.append(RESTTestRunner.PARA_CLASS_NAME).append("=").append(testClass);
+        }
+        if (methodName != null) {
+            if (first) {
+                first = false;
+                url.append("?");
+            } else {
+                url.append("&");
+            }
+            url.append(RESTTestRunner.PARA_METHOD_NAME).append("=").append(methodName);
+        }
+
+        try {
+            return new URL(url.toString());
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create url", e);
+        }
+    }
+
+    public static class MockTestExecutor implements TestMethodExecutor, Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        public void invoke(Object... parameters) throws Throwable {
+        }
+
+        public String getMethodName() {
+            return getMethod().getName();
+        }
+
+        public Method getMethod() {
+            try {
+                return this.getClass().getMethod("getMethod");
+            } catch (Exception e) {
+                throw new RuntimeException("Could not find my own method ?? ");
+            }
+        }
+
+        public Object getInstance() {
+            return this;
+        }
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/BaseRESTProtocolTestCase.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/BaseRESTProtocolTestCase.java
@@ -1,0 +1,147 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.protocol.servlet5.ServletProtocolConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * RESTProtocolTestCase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class BaseRESTProtocolTestCase {
+    @Test
+    public void shouldFindTestServletInMetadata() throws Exception {
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+
+        HTTPContext testContext = new HTTPContext("127.0.0.1", 8080)
+            .add(new Servlet(RESTMethodExecutor.ARQUILLIAN_REST_NAME, "test"));
+
+        Method testMethod = getTestMethod("testNoAnnotations");
+
+        RESTURIHandler handler = new RESTURIHandler(config, to(testContext));
+        URI result = handler.locateTestServlet(testMethod);
+
+        Assert.assertEquals("http://127.0.0.1:8080/test", result.toString());
+    }
+
+    @Test
+    public void shouldOverrideMetadata() throws Exception {
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+        config.setScheme("https");
+        config.setHost("10.10.10.1");
+        config.setPort(90);
+
+        HTTPContext testContext = new HTTPContext("127.0.0.1", 8080)
+            .add(new Servlet(RESTMethodExecutor.ARQUILLIAN_REST_NAME, "test"));
+
+        Method testMethod = getTestMethod("testNoAnnotations");
+
+        RESTURIHandler handler = new RESTURIHandler(config, to(testContext));
+        URI result = handler.locateTestServlet(testMethod);
+
+        Assert.assertEquals("https://10.10.10.1:90/test", result.toString());
+    }
+
+    @Test
+    public void shouldMatchNamedTargetedContext() throws Exception {
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+
+        HTTPContext testContextOne = new HTTPContext("Y", "127.0.0.1", 8080)
+            .add(new Servlet(RESTMethodExecutor.ARQUILLIAN_REST_NAME, "test"));
+
+        HTTPContext testContextTwo = new HTTPContext("X", "127.0.0.1", 8081)
+            .add(new Servlet(RESTMethodExecutor.ARQUILLIAN_REST_NAME, "test"));
+
+        Method testMethod = getTestMethod("testTargeted");
+
+        RESTURIHandler handler = new RESTURIHandler(config, to(testContextOne, testContextTwo));
+        URI result = handler.locateTestServlet(testMethod);
+
+        Assert.assertEquals("http://127.0.0.1:8081/test", result.toString());
+    }
+
+    @Test
+    public void shouldOverrideMatchNamedTargetedContext() throws Exception {
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+        config.setScheme("https");
+        config.setHost("10.10.10.1");
+        config.setPort(90);
+
+        HTTPContext testContextOne = new HTTPContext("Y", "127.0.0.1", 8080)
+            .add(new Servlet(RESTMethodExecutor.ARQUILLIAN_REST_NAME, "testY"));
+
+        HTTPContext testContextTwo = new HTTPContext("X", "127.0.0.1", 8081)
+            .add(new Servlet(RESTMethodExecutor.ARQUILLIAN_REST_NAME, "testX"));
+
+        Method testMethod = getTestMethod("testTargeted");
+
+        RESTURIHandler handler = new RESTURIHandler(config, to(testContextOne, testContextTwo));
+        URI result = handler.locateTestServlet(testMethod);
+
+        Assert.assertEquals("https://10.10.10.1:90/testX", result.toString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionOnMissingNamedTargetedContext() throws Exception {
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+
+        HTTPContext testContextOne = new HTTPContext("Y", "127.0.0.1", 8080)
+            .add(new Servlet(RESTMethodExecutor.ARQUILLIAN_REST_NAME, "test"));
+
+        Method testMethod = getTestMethod("testTargeted");
+
+        RESTURIHandler handler = new RESTURIHandler(config, to(testContextOne));
+        handler.locateTestServlet(testMethod);
+    }
+
+    private Collection<HTTPContext> to(HTTPContext... inputs) {
+        List<HTTPContext> contexts = new ArrayList<HTTPContext>();
+        Collections.addAll(contexts, inputs);
+        return contexts;
+    }
+
+    private Method getTestMethod(String methodName) throws Exception {
+        return getClass().getDeclaredMethod(methodName);
+    }
+
+
+   /*
+    * Methods used for RESTURIHandler HTTPContext lookups. 
+    */
+
+    @SuppressWarnings("unused")
+    private void testNoAnnotations() {
+    }
+
+    @TargetsContainer("X")
+    private void testTargeted() {
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/ProtocolDeploymentAppenderTestCase.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/ProtocolDeploymentAppenderTestCase.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * ProtocolDeploymentAppenderTestCase
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ProtocolDeploymentAppenderTestCase {
+
+    @Test
+    public void shouldGenerateDependencies() throws Exception {
+
+        Archive<?> archive = new RESTDeploymentAppender().createAuxiliaryArchive();
+
+        Assert.assertFalse(
+            "Should not have added web-fragment.xml",
+            archive.contains(ArchivePaths.create("META-INF/web-fragment.xml"))
+        );
+
+        Assert.assertTrue(
+            "Should have added " + RemoteLoadableExtension.class.getName(),
+            archive.contains(ArchivePaths.create("META-INF/services/" + RemoteLoadableExtension.class.getName()))
+        );
+
+        System.out.println(archive.toString(true));
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/ProtocolTestCase.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/ProtocolTestCase.java
@@ -1,0 +1,144 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.net.URL;
+
+import org.jboss.arquillian.protocol.rest.test.MockTestRunner;
+import org.jboss.arquillian.protocol.rest.test.TestCommandCallback;
+import org.jboss.arquillian.protocol.servlet5.ServletProtocolConfiguration;
+import org.jboss.arquillian.protocol.rest.runner.RESTTestRunner;
+import org.jboss.arquillian.test.spi.TestResult;
+import org.jboss.arquillian.test.spi.TestResult.Status;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * ProtocolTestCase
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ProtocolTestCase extends AbstractServerBase {
+
+    @Test
+    public void shouldReturnTestResult() throws Exception {
+        MockTestRunner.add(TestResult.passed());
+
+        RESTMethodExecutor executor = createExecutor();
+        TestResult result = executor.invoke(new MockTestExecutor());
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            MockTestRunner.wantedResults.getStatus(),
+            result.getStatus());
+
+        Assert.assertNull(
+            "No Exception should have been thrown",
+            result.getThrowable());
+    }
+
+    @Test
+    public void shouldUseLogicalMethodNameAndSupportUrlReservedCharactersInIt() throws Exception {
+        final String testMethodNameWithReservedUrlCharacters = "non standard!test&name";
+
+        MockTestRunner.add(TestResult.passed());
+
+        RESTMethodExecutor executor = createExecutor();
+        executor.invoke(new MockTestExecutor() {
+            @Override
+            public String getMethodName() {
+                return testMethodNameWithReservedUrlCharacters;
+            }
+        });
+
+        Assert.assertEquals(
+            "Should use the logical method name",
+            testMethodNameWithReservedUrlCharacters,
+            MockTestRunner.testRequests.get(0).getMethodName()
+        );
+    }
+
+    @Test
+    public void shouldReturnThrownException() throws Exception {
+        MockTestRunner.add(TestResult.failed(new Exception().fillInStackTrace()));
+
+        RESTMethodExecutor executor = createExecutor();
+        TestResult result = executor.invoke(new MockTestExecutor());
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            MockTestRunner.wantedResults.getStatus(),
+            result.getStatus());
+
+        Assert.assertNotNull(
+            "Exception should have been thrown",
+            result.getThrowable());
+    }
+
+    @Test
+    public void shouldReturnExceptionWhenMissingTestClassParameter() throws Exception {
+        URL url = createURL(RESTTestRunner.OUTPUT_MODE_SERIALIZED, null, null);
+        TestResult result = (TestResult) TestUtil.execute(url);
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            Status.FAILED,
+            result.getStatus());
+
+        Assert.assertTrue(
+            "No Exception should have been thrown",
+            result.getThrowable() instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void shouldReturnExceptionWhenMissingMethodParameter() throws Exception {
+        URL url = createURL(RESTTestRunner.OUTPUT_MODE_SERIALIZED, "org.my.test", null);
+        TestResult result = (TestResult) TestUtil.execute(url);
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            Status.FAILED,
+            result.getStatus());
+
+        Assert.assertTrue(
+            "No Exception should have been thrown",
+            result.getThrowable() instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void shouldReturnExceptionWhenErrorLoadingClass() throws Exception {
+        URL url = createURL(RESTTestRunner.OUTPUT_MODE_SERIALIZED, "org.my.test", "test");
+        TestResult result = (TestResult) TestUtil.execute(url);
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            Status.FAILED,
+            result.getStatus());
+
+        Assert.assertTrue(
+            "No Exception should have been thrown",
+            result.getThrowable() instanceof ClassNotFoundException);
+    }
+
+    protected RESTMethodExecutor createExecutor() {
+        return new RESTMethodExecutor(
+            new ServletProtocolConfiguration(),
+            createContexts(),
+            new TestCommandCallback());
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/RESTCommandServiceTestCase.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/RESTCommandServiceTestCase.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.lang.reflect.Field;
+
+import org.jboss.arquillian.protocol.rest.test.MockTestRunner;
+import org.jboss.arquillian.protocol.rest.test.TestCommandCallback;
+import org.jboss.arquillian.protocol.rest.test.TestIntegerCommand;
+import org.jboss.arquillian.protocol.rest.test.TestStringCommand;
+import org.jboss.arquillian.protocol.servlet5.ServletProtocolConfiguration;
+import org.jboss.arquillian.protocol.rest.runner.RESTCommandService;
+import org.jboss.arquillian.test.spi.TestResult;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * RESTCommandServiceTestCase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class RESTCommandServiceTestCase extends AbstractServerBase {
+    @Test
+    public void shouldBeAbleToTransfereCommand() throws Exception {
+        Object[] results = new Object[] {"Wee", 100};
+
+        MockTestRunner.add(TestResult.passed());
+        MockTestRunner.add(new TestStringCommand());
+        MockTestRunner.add(new TestIntegerCommand());
+
+        RESTMethodExecutor executor = new RESTMethodExecutor(
+            new ServletProtocolConfiguration(),
+            createContexts(),
+            new TestCommandCallback(results));
+
+        TestResult result = executor.invoke(new MockTestExecutor());
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            MockTestRunner.wantedResults.getStatus(),
+            result.getStatus());
+
+        Assert.assertNull(
+            "Exception should have been thrown",
+            result.getThrowable());
+
+        Assert.assertEquals(
+            "Should have returned command",
+            results[0],
+            MockTestRunner.commandResults.get(0));
+
+        Assert.assertEquals(
+            "Should have returned command",
+            results[1],
+            MockTestRunner.commandResults.get(1));
+    }
+
+    @Test
+    public void shouldDisableCommandService() throws Exception {
+        Field f = RESTCommandService.class.getDeclaredField("TIMEOUT");
+        f.setAccessible(true);
+        f.set(null, 500);
+
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+        config.setPullInMilliSeconds(0);
+
+        Object[] results = new Object[] {"Wee", 100};
+
+        MockTestRunner.add(TestResult.failed(null));
+        MockTestRunner.add(new TestStringCommand());
+
+        RESTMethodExecutor executor = new RESTMethodExecutor(
+            config,
+            createContexts(),
+            new TestCommandCallback(results));
+
+        TestResult result = executor.invoke(new MockTestExecutor());
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            MockTestRunner.wantedResults.getStatus(),
+            result.getStatus());
+
+        Assert.assertNotNull(
+            "Exception should have been thrown",
+            result.getThrowable());
+
+        Assert.assertTrue(
+            "Timeout exception should have been thrown",
+            result.getThrowable().getMessage().contains("timeout"));
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/RESTDeploymentPackagerTestCase.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/RESTDeploymentPackagerTestCase.java
@@ -1,0 +1,299 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.jboss.arquillian.container.spi.client.deployment.Validate;
+import org.jboss.arquillian.container.test.api.Testable;
+import org.jboss.arquillian.container.test.spi.TestDeployment;
+import org.jboss.arquillian.container.test.spi.client.deployment.ProtocolArchiveProcessor;
+import org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.application.ApplicationDescriptor;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * RESTDeploymentPackagerTestCase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class RESTDeploymentPackagerTestCase {
+    @Test
+    public void shouldHandleJavaArchive() throws Exception {
+        Archive<?> archive = new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null,
+                ShrinkWrap.create(JavaArchive.class, "applicationArchive.jar"),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertTrue(
+            "Verify that a defined JavaArchive using EE6 JavaArchive protocol is build as WebArchive",
+            Validate.isArchiveOfType(WebArchive.class, archive));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/arquillian-jakarta-rest-protocol.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/auxiliaryArchive2.jar")));
+
+        Assert.assertTrue(
+            "Verify that the applicationArchive is placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/applicationArchive.jar")));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test
+    public void shouldHandleWebArchive() throws Exception {
+        Archive<?> archive = new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null,
+                ShrinkWrap.create(WebArchive.class, "applicationArchive.war"),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertTrue(
+            "Verify that a defined WebArchive using EE9 JavaArchive protocol is build as WebArchive",
+            Validate.isArchiveOfType(WebArchive.class, archive));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/arquillian-jakarta-rest-protocol.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/auxiliaryArchive1.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/auxiliaryArchive2.jar")));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test
+    public void shouldHandleEnterpriseArchive() throws Exception {
+        Archive<?> archive = new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear"),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /",
+            archive.contains(ArchivePaths.create(JarNameProcessor.jarName)));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive1.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive2.jar")));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test
+    public void shouldHandleEnterpriseArchiveWithApplicationXML() throws Exception {
+        Archive<?> archive = new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
+                    .setApplicationXML(createApplicationDescriptor()),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /",
+            archive.contains(ArchivePaths.create(JarNameProcessor.jarName)));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive1.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive2.jar")));
+
+        String applicationXmlContent =
+            TestUtil.convertToString(archive.get("META-INF/application.xml").getAsset().openStream());
+        Assert.assertTrue(
+            "verify that the arquillian-jakarta-rest-protocol.war was added to the application.xml",
+            applicationXmlContent.contains(String.format("<web-uri>%s</web-uri>", JarNameProcessor.jarName)));
+
+        // ARQ-670
+        Assert.assertTrue(
+            "verify that the arquillian-jakarta-rest-protocol.war has correct context-root in application.xml",
+            applicationXmlContent.contains(String.format("<context-root>%s</context-root>",
+                    JarNameProcessor.jarName.replaceFirst(".war$", ""))));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test
+    public void shouldHandleEnterpriseArchiveWithWebArchive() throws Exception {
+        WebArchive applicationWar = ShrinkWrap.create(WebArchive.class, "applicationArchive.war");
+
+        Archive<?> archive = new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
+                    .addAsModule(applicationWar),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertFalse(
+            "Verify that the auxiliaryArchives was not added",
+            archive.contains(ArchivePaths.create("arquillian-jakarta-rest-protocol.war")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive1.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive2.jar")));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionOnUnknownArchiveType() throws Exception {
+        new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null, ShrinkWrap.create(ResourceAdapterArchive.class), new ArrayList<Archive<?>>()),
+            processors()
+        );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldThrowExceptionOnEnterpriseArchiveWithMultipleWebArchive() throws Exception {
+        new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
+                    .addAsModule(ShrinkWrap.create(WebArchive.class))
+                    .addAsModule(ShrinkWrap.create(WebArchive.class)),
+                createAuxiliaryArchives()),
+            processors());
+    }
+
+    @Test
+    public void shouldHandleEnterpriseArchiveWithMultipleWebArchiveAndOneMarkedWebArchive() throws Exception {
+        WebArchive testableArchive = Testable.archiveToTest(ShrinkWrap.create(WebArchive.class));
+
+        Archive<?> archive = new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
+                    .addAsModule(testableArchive)
+                    .addAsModule(ShrinkWrap.create(WebArchive.class)),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertFalse(
+            "Verify that the auxiliaryArchives was not added",
+            archive.contains(ArchivePaths.create("arquillian-jakarta-rest-protocol.war")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive1.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive2.jar")));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldThrowExceptionOnEnterpriseArchiveWithMultipleMarkedWebArchives() throws Exception {
+        new RESTDeploymentPackager().generateDeployment(
+            new TestDeployment(null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
+                    .addAsModule(Testable.archiveToTest(ShrinkWrap.create(WebArchive.class)))
+                    .addAsModule(Testable.archiveToTest(ShrinkWrap.create(WebArchive.class))),
+                createAuxiliaryArchives()),
+            processors());
+    }
+
+    private Collection<Archive<?>> createAuxiliaryArchives() {
+        List<Archive<?>> archives = new ArrayList<Archive<?>>();
+        archives.add(ShrinkWrap.create(JavaArchive.class, "auxiliaryArchive1.jar"));
+        archives.add(ShrinkWrap.create(JavaArchive.class, "auxiliaryArchive2.jar"));
+
+        return archives;
+    }
+
+    private Asset createApplicationDescriptor() {
+        return new StringAsset(
+            Descriptors.create(ApplicationDescriptor.class)
+                .version("6")
+                .ejbModule("test.jar")
+                .exportAsString());
+    }
+
+    private Collection<ProtocolArchiveProcessor> processors() {
+        List<ProtocolArchiveProcessor> pros = new ArrayList<ProtocolArchiveProcessor>();
+        pros.add(new DummyProcessor());
+        pros.add(new JarNameProcessor());
+        return pros;
+    }
+
+    private static class DummyProcessor implements ProtocolArchiveProcessor {
+        public static boolean wasCalled = false;
+
+        public DummyProcessor() {
+            wasCalled = false;
+        }
+
+        @Override
+        public void process(TestDeployment testDeployment, Archive<?> protocolArchive) {
+            wasCalled = true;
+        }
+    }
+
+    private static class JarNameProcessor implements ProtocolArchiveProcessor {
+        static String jarName;
+
+        @Override
+        public void process(TestDeployment testDeployment, Archive<?> protocolArchive) {
+            jarName = protocolArchive.getName();
+        }
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/TestUtil.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/TestUtil.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.net.URL;
+
+/**
+ * TestUtil
+ * <p>
+ * Internal helper for testcase to do http request
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestUtil {
+    private TestUtil() {
+    }
+
+    public static Object execute(URL url) {
+        ObjectInputStream input = null;
+        try {
+            input = new ObjectInputStream(url.openStream());
+            return input.readObject();
+        } catch (Exception e) {
+            throw new RuntimeException("Could not fetch url " + url);
+        } finally {
+            close(input);
+        }
+    }
+
+    private static void close(InputStream input) {
+        if (input == null) {
+            return;
+        }
+        try {
+            input.close();
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
+    public static String convertToString(InputStream in) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int b;
+        while ((b = in.read()) != -1) {
+            out.write(b);
+        }
+        out.close();
+        in.close();
+        return new String(out.toByteArray(), "UTF-8");
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/test/MockTestRunner.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/test/MockTestRunner.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.test;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.jboss.arquillian.container.test.spi.TestRunner;
+import org.jboss.arquillian.container.test.spi.command.Command;
+import org.jboss.arquillian.protocol.rest.runner.RESTCommandService;
+import org.jboss.arquillian.test.spi.TestResult;
+
+/**
+ * MockTestRunner
+ * <p>
+ * TestRunner that will return what you want for testing
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class MockTestRunner implements TestRunner {
+    public static TestResult wantedResults;
+
+    public static List<Command<?>> commands = new ArrayList<Command<?>>();
+    public static List<Object> commandResults = new ArrayList<Object>();
+
+    public static List<TestRequest> testRequests = new ArrayList<TestRequest>();
+
+    public static void add(Command<?> command) {
+        commands.add(command);
+    }
+
+    public static void add(TestResult wantedTestResult) {
+        wantedResults = wantedTestResult;
+    }
+
+    public static void clear() {
+        wantedResults = null;
+        commands.clear();
+        commandResults.clear();
+        testRequests.clear();
+    }
+
+    public TestResult execute(Class<?> testClass, String methodName) {
+        testRequests.add(new TestRequest(testClass, methodName));
+        for (Command<?> command : commands) {
+            commandResults.add(new RESTCommandService().execute(command));
+        }
+
+        return wantedResults;
+    }
+
+    public static class TestRequest {
+        private final Class<?> testClass;
+        private final String methodName;
+
+        public TestRequest(Class<?> testClass, String methodName) {
+            this.testClass = testClass;
+            this.methodName = methodName;
+        }
+
+        public Class<?> getTestClass() {
+            return testClass;
+        }
+
+        public String getMethodName() {
+            return methodName;
+        }
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/test/TestCommandCallback.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/test/TestCommandCallback.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.test;
+
+import org.jboss.arquillian.container.test.spi.command.Command;
+import org.jboss.arquillian.container.test.spi.command.CommandCallback;
+
+/**
+ * TestRemoteCommandCallback
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestCommandCallback implements CommandCallback {
+    private Object[] results;
+
+    private int invocationCount = 0;
+
+    public TestCommandCallback(Object... object) {
+        results = object;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    public void fired(Command event) {
+        event.setResult(results[invocationCount++]);
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/test/TestIntegerCommand.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/test/TestIntegerCommand.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.test;
+
+import java.io.Serializable;
+import org.jboss.arquillian.container.test.spi.command.Command;
+
+/**
+ * TestRemoteCommand
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestIntegerCommand implements Command<Integer>, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Integer result;
+    private Throwable throwable;
+
+    @Override
+    public Integer getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(Integer result) {
+        this.result = result;
+    }
+
+    @Override
+    public Throwable getThrowable() {
+        return throwable;
+    }
+
+    @Override
+    public void setThrowable(Throwable throwable) {
+        this.throwable = throwable;
+    }
+}

--- a/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/test/TestStringCommand.java
+++ b/protocols/rest-jakarta/src/test/java/org/jboss/arquillian/protocol/rest/test/TestStringCommand.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.rest.test;
+
+import java.io.Serializable;
+import org.jboss.arquillian.container.test.spi.command.Command;
+
+/**
+ * TestRemoteCommand
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestStringCommand implements Command<String>, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String result;
+    private Throwable throwable;
+
+    @Override
+    public String getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(String result) {
+        this.result = result;
+    }
+
+    @Override
+    public Throwable getThrowable() {
+        return throwable;
+    }
+
+    @Override
+    public void setThrowable(Throwable throwable) {
+        this.throwable = throwable;
+    }
+}

--- a/protocols/rest-jakarta/src/test/resources/META-INF/services/org.jboss.arquillian.container.test.spi.TestRunner
+++ b/protocols/rest-jakarta/src/test/resources/META-INF/services/org.jboss.arquillian.container.test.spi.TestRunner
@@ -1,0 +1,1 @@
+org.jboss.arquillian.protocol.rest.test.MockTestRunner

--- a/protocols/servlet-jakarta/README.adoc
+++ b/protocols/servlet-jakarta/README.adoc
@@ -1,0 +1,10 @@
+= Jakarta EE 9 Servlet 5 and Jakarta EE 10 Servlet 6 API Protocols
+
+This is a port of the servlet protocol handler for communicating using a servlet / http following the Jakarta Servlet 5.x-6.x specs.
+
+== Issues
+This relies on a release of org.eclipse.jetty:jetty-server that supports the Jakarta Servlet 5.x-6.x specs. The current
+11.0.0-alpha0 release in turn requires Java 11, so this module required Java 8 to compile the module artifact, but
+it requires Java 11 to build and run the modules tests.
+
+https://github.com/eclipse/jetty.project

--- a/protocols/servlet-jakarta/pom.xml
+++ b/protocols/servlet-jakarta/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <!-- Parent -->
+  <parent>
+    <groupId>org.jboss.arquillian.jakarta</groupId>
+    <artifactId>arquillian-parent-jakarta</artifactId>
+    <version>1.8.1.Final-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <!-- Model Version -->
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Artifact Configuration -->
+  <groupId>org.jboss.arquillian.protocol</groupId>
+  <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
+  <name>Arquillian Protocol Servlet 5.x</name>
+  <description>Protocol handler for communicating using a servlet / http following the Servlet 5.x spec and jakarta.servlet.* apis
+  </description>
+
+  <!-- Properties -->
+  <properties>
+    <!-- Versioning -->
+    <version.jetty_jetty>11.0.14</version.jetty_jetty>
+    <version.servlet-api>5.0.0</version.servlet-api>
+  </properties>
+
+  <!-- Dependencies -->
+  <dependencies>
+
+    <!-- org.jboss.arquillian -->
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-impl-base</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+      <artifactId>shrinkwrap-descriptors-spi</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- servlet api -->
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${version.servlet-api}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.shrinkwrap</groupId>
+      <artifactId>shrinkwrap-impl-base</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>${version.jetty_jetty}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <version>${version.jetty_jetty}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/BaseServletProtocol.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/BaseServletProtocol.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5;
+
+import java.util.Collection;
+import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
+import org.jboss.arquillian.container.test.spi.command.CommandCallback;
+
+/**
+ * BaseServletProtocol
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ */
+public abstract class BaseServletProtocol implements Protocol<ServletProtocolConfiguration> {
+    /* (non-Javadoc)
+     * @see org.jboss.arquillian.spi.client.protocol.Protocol#getProtocolConfigurationClass()
+     */
+    @Override
+    public Class<ServletProtocolConfiguration> getProtocolConfigurationClass() {
+        return ServletProtocolConfiguration.class;
+    }
+
+    /* (non-Javadoc)
+     * @see org.jboss.arquillian.spi.client.protocol.Protocol#getDescription()
+     */
+    @Override
+    public ProtocolDescription getDescription() {
+        return new ProtocolDescription(getProtocolName());
+    }
+
+    /* (non-Javadoc)
+     * @see org.jboss.arquillian.spi.client.protocol.Protocol#getExecutor(org.jboss.arquillian.spi.client.protocol.ProtocolConfiguration, org.jboss.arquillian.spi.client.protocol.metadata.ProtocolMetaData)
+     */
+    @Override
+    public ServletMethodExecutor getExecutor(ServletProtocolConfiguration protocolConfiguration,
+        ProtocolMetaData metaData, CommandCallback callback) {
+        Collection<HTTPContext> contexts = metaData.getContexts(HTTPContext.class);
+        if (contexts.size() == 0) {
+            throw new IllegalArgumentException(
+                "No " + HTTPContext.class.getName() + " found in " + ProtocolMetaData.class.getName() + ". " +
+                    "Servlet protocol can not be used");
+        }
+        return new ServletMethodExecutor(protocolConfiguration, contexts, callback);
+    }
+
+    protected abstract String getProtocolName();
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/Processor.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/Processor.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5;
+
+import java.util.Collection;
+import org.jboss.arquillian.container.test.spi.TestDeployment;
+import org.jboss.arquillian.container.test.spi.client.deployment.ProtocolArchiveProcessor;
+import org.jboss.shrinkwrap.api.Archive;
+
+/**
+ * Processor
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class Processor {
+    private TestDeployment deployment;
+    private Collection<ProtocolArchiveProcessor> processors;
+
+    public Processor(TestDeployment deployment, Collection<ProtocolArchiveProcessor> processors) {
+        this.deployment = deployment;
+        this.processors = processors;
+    }
+
+    public void process(Archive<?> protocol) {
+        for (ProtocolArchiveProcessor processor : processors) {
+            processor.process(deployment, protocol);
+        }
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/ServletExtension.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/ServletExtension.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5;
+
+import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.protocol.servlet5.runner.ServletContextResourceProvider;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+/**
+ * ServletExtension
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ServletExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(Protocol.class, org.jboss.arquillian.protocol.servlet5.v_5.ServletProtocol.class)
+            .service(Protocol.class, org.jboss.arquillian.protocol.servlet5.v_6.ServletProtocol.class);
+
+        if (Validate.classExists("jakarta.servlet.ServletContext")) {
+            builder.service(ResourceProvider.class, ServletContextResourceProvider.class);
+        }
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/ServletMethodExecutor.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/ServletMethodExecutor.java
@@ -1,0 +1,240 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5;
+
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.net.ConnectException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLEncoder;
+import java.util.Collection;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Logger;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.test.spi.ContainerMethodExecutor;
+import org.jboss.arquillian.container.test.spi.command.Command;
+import org.jboss.arquillian.container.test.spi.command.CommandCallback;
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+import org.jboss.arquillian.test.spi.TestResult;
+
+/**
+ * ServletMethodExecutor
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ServletMethodExecutor implements ContainerMethodExecutor {
+    public static final String ARQUILLIAN_SERVLET_NAME = "ArquillianServletRunnerEE9";
+    public static final String ARQUILLIAN_SERVLET_MAPPING = "/" + ARQUILLIAN_SERVLET_NAME;
+    private static final Logger log = Logger.getLogger(ContainerMethodExecutor.class.getName());
+    protected ServletURIHandler uriHandler;
+    protected CommandCallback callback;
+    protected ServletProtocolConfiguration config;
+
+    protected ServletMethodExecutor() {
+    }
+
+    public ServletMethodExecutor(ServletProtocolConfiguration config, Collection<HTTPContext> contexts,
+        final CommandCallback callback) {
+        if (config == null) {
+            throw new IllegalArgumentException("ServletProtocolConfiguration must be specified");
+        }
+        if (contexts == null || contexts.size() == 0) {
+            throw new IllegalArgumentException("HTTPContext must be specified");
+        }
+        if (callback == null) {
+            throw new IllegalArgumentException("Callback must be specified");
+        }
+        this.config = config;
+        this.uriHandler = new ServletURIHandler(config, contexts);
+        this.callback = callback;
+    }
+
+    public TestResult invoke(final TestMethodExecutor testMethodExecutor) {
+        if (testMethodExecutor == null) {
+            throw new IllegalArgumentException("TestMethodExecutor must be specified");
+        }
+
+        URI targetBaseURI = uriHandler.locateTestServlet(testMethodExecutor.getMethod());
+
+        Class<?> testClass = testMethodExecutor.getInstance().getClass();
+
+        Timer eventTimer = null;
+        Lock timerLock = new ReentrantLock();
+        AtomicBoolean isCanceled = new AtomicBoolean();
+        try {
+            String urlEncodedMethodName = URLEncoder.encode(testMethodExecutor.getMethodName(), "UTF-8");
+            final String url = targetBaseURI.toASCIIString() + ARQUILLIAN_SERVLET_MAPPING
+                + "?outputMode=serializedObject&className=" + testClass.getName() + "&methodName="
+                + urlEncodedMethodName;
+
+            final String eventUrl = targetBaseURI.toASCIIString() + ARQUILLIAN_SERVLET_MAPPING
+                + "?outputMode=serializedObject&className=" + testClass.getName() + "&methodName="
+                + urlEncodedMethodName + "&cmd=event";
+
+            eventTimer = createCommandServicePullTimer(eventUrl, timerLock, isCanceled);
+            return executeWithRetry(url, TestResult.class);
+        } catch (Exception e) {
+            throw new IllegalStateException("Error launching test " + testClass.getName() + " "
+                + testMethodExecutor.getMethod(), e);
+        } finally {
+            if (eventTimer != null) {
+                eventTimer.cancel();
+                timerLock.lock();
+                try {
+                    isCanceled.set(true);
+                } finally {
+                    timerLock.unlock();
+                }
+            }
+        }
+    }
+
+    protected <T> T executeWithRetry(String url, Class<T> type) throws Exception {
+        long timeoutTime = System.currentTimeMillis() + 1000;
+        boolean interrupted = false;
+        while (timeoutTime > System.currentTimeMillis()) {
+            T o = execute(url, type, null);
+            if (o != null) {
+                return o;
+            }
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                interrupted = true;
+            }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+        throw new IllegalStateException("Error launching request at " + url + ". No result returned");
+    }
+
+    protected <T> T execute(String url, Class<T> returnType, Object requestObject) throws Exception {
+        URLConnection connection = new URL(url).openConnection();
+        if (!(connection instanceof HttpURLConnection)) {
+            throw new IllegalStateException("Not an http connection! " + connection);
+        }
+        HttpURLConnection httpConnection = (HttpURLConnection) connection;
+        httpConnection.setUseCaches(false);
+        httpConnection.setDefaultUseCaches(false);
+        httpConnection.setDoInput(true);
+
+        prepareHttpConnection(httpConnection);
+
+        try {
+
+            if (requestObject != null) {
+                httpConnection.setRequestMethod("POST");
+                httpConnection.setDoOutput(true);
+                httpConnection.setRequestProperty("Content-Type", "application/octet-stream");
+            }
+
+            if (requestObject != null) {
+                ObjectOutputStream ous = new ObjectOutputStream(httpConnection.getOutputStream());
+                try {
+                    ous.writeObject(requestObject);
+                } catch (Exception e) {
+                    throw new RuntimeException("Error sending request Object, " + requestObject, e);
+                } finally {
+                    ous.flush();
+                    ous.close();
+                }
+            }
+
+            try {
+                httpConnection.getResponseCode();
+            } catch (ConnectException e) {
+                return null; // Could not connect
+            }
+            if (httpConnection.getResponseCode() == HttpURLConnection.HTTP_OK) {
+                ObjectInputStream ois = new ObjectInputStream(httpConnection.getInputStream());
+                Object o;
+                try {
+                    o = ois.readObject();
+                } finally {
+                    ois.close();
+                }
+
+                if (!returnType.isInstance(o)) {
+                    throw new IllegalStateException(
+                        "Error reading results, expected a " + returnType.getName() + " but got " + o);
+                }
+                return returnType.cast(o);
+            } else if (httpConnection.getResponseCode() == HttpURLConnection.HTTP_NO_CONTENT) {
+                return null;
+            } else if (httpConnection.getResponseCode() != HttpURLConnection.HTTP_NOT_FOUND) {
+                throw new IllegalStateException(
+                    "Error launching test at " + url + ". " +
+                        "Got " + httpConnection.getResponseCode() + " (" + httpConnection.getResponseMessage() + ")");
+            }
+        } finally {
+            httpConnection.disconnect();
+        }
+        return null;
+    }
+
+    @SuppressWarnings("UnusedParameters")
+    protected void prepareHttpConnection(HttpURLConnection connection) {
+    }
+
+    protected Timer createCommandServicePullTimer(final String eventUrl,
+            final Lock timerLock, final AtomicBoolean isCanceled) {
+        if (config.getPullInMilliSeconds() == null || config.getPullInMilliSeconds() <= 0) {
+            log.warning("The Servlet Protocol has been configured with a pullInMilliSeconds interval of " +
+                config.getPullInMilliSeconds() + ". The effect of this is that the Command Service has been disabled." +
+                " Depending on which features you use, this might cause serious delays. Be on high alert for " +
+                " possible timeout runtime exceptions.");
+            return null;
+        }
+        Timer eventTimer = new Timer();
+        eventTimer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                timerLock.lock();
+                try {
+                    if (isCanceled.get()) {
+                        return;
+                    }
+                    Object o = execute(eventUrl, Object.class, null);
+                    if (o != null) {
+                        if (o instanceof Command) {
+                            Command<?> command = (Command<?>) o;
+                            callback.fired(command);
+                            execute(eventUrl, Object.class, command);
+                        } else {
+                            throw new RuntimeException("Recived a non " + Command.class.getName()
+                                + " object on event channel");
+                        }
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    timerLock.unlock();
+                }
+            }
+        }, 0, config.getPullInMilliSeconds());
+        return eventTimer;
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/ServletProtocolConfiguration.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/ServletProtocolConfiguration.java
@@ -1,0 +1,119 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5;
+
+import java.net.URI;
+import org.jboss.arquillian.container.test.spi.client.protocol.ProtocolConfiguration;
+
+/**
+ * ServletProtocolConfiguration
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ServletProtocolConfiguration implements ProtocolConfiguration {
+    private String scheme = null;
+    private String host = null;
+    private Integer port = null;
+    private String contextRoot = null;
+    ;
+    private Integer pullInMilliSeconds = 100;
+
+    /**
+     * @return the scheme
+     */
+    public String getScheme() {
+        return scheme;
+    }
+
+    /**
+     * @param scheme
+     *     the scheme to set
+     */
+    public void setScheme(String scheme) {
+        this.scheme = scheme;
+    }
+
+    /**
+     * @return the host
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * @param host
+     *     the host to set
+     */
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    /**
+     * @return the port
+     */
+    public Integer getPort() {
+        return port;
+    }
+
+    /**
+     * @param port
+     *     the port to set
+     */
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    /**
+     * @return the context
+     */
+    public String getContextRoot() {
+        return contextRoot;
+    }
+
+    /**
+     * @param context
+     *     the context to set
+     */
+    public void setContextRoot(String context) {
+        this.contextRoot = context;
+    }
+
+    public URI getBaseURI() {
+        return URI.create(scheme + "://" + host + ":" + port + "/" + contextRoot);
+    }
+
+    /**
+     * @return
+     */
+    public Integer getPullInMilliSeconds() {
+        return pullInMilliSeconds;
+    }
+
+    /**
+     * The Command Service provided by the Serlvet protocol will pull
+     * for Remote events happened in the container every x milliseconds.
+     * <p>
+     * This is used by certain extensions to send data/commands between the container
+     * and client. Used by e.g. The InContianer Deployment.
+     * <p>
+     * Set the given pull interval time in milliseconds.
+     */
+    public void setPullInMilliSeconds(Integer pullInMilliSeconds) {
+        this.pullInMilliSeconds = pullInMilliSeconds;
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/ServletURIHandler.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/ServletURIHandler.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.Collection;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+
+/**
+ * ServletURIHandler
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ServletURIHandler {
+
+    private ServletProtocolConfiguration config;
+
+    private Collection<HTTPContext> contexts;
+
+    /**
+     *
+     */
+    public ServletURIHandler(ServletProtocolConfiguration config, Collection<HTTPContext> contexts) {
+        if (config == null) {
+            throw new IllegalArgumentException("ServletProtocolConfiguration must be specified");
+        }
+        if (contexts == null || contexts.size() == 0) {
+            throw new IllegalArgumentException("HTTPContext must be specified");
+        }
+        this.config = config;
+        this.contexts = contexts;
+    }
+
+    public URI locateTestServlet(Method method) {
+        HTTPContext context = locateHTTPContext(method);
+        return ServletUtil.determineBaseURI(
+            config,
+            context,
+            ServletMethodExecutor.ARQUILLIAN_SERVLET_NAME);
+    }
+
+    protected HTTPContext locateHTTPContext(Method method) {
+        TargetsContainer targetContainer = method.getAnnotation(TargetsContainer.class);
+        if (targetContainer != null) {
+            String targetName = targetContainer.value();
+
+            for (HTTPContext context : contexts) {
+                if (targetName.equals(context.getName())) {
+                    return context;
+                }
+            }
+            throw new IllegalArgumentException("Could not determin HTTPContext from ProtocolMetadata for target: "
+                + targetName + ". Verify that the given target name in @" + TargetsContainer.class.getSimpleName()
+                + " match a name returned by the deployment container");
+        }
+        return contexts.toArray(new HTTPContext[] {})[0];
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/ServletUtil.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/ServletUtil.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5;
+
+import java.net.URI;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+
+/**
+ * ServletUtil
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public final class ServletUtil {
+    public static final ArchivePath WEB_XML_PATH = ArchivePaths.create("WEB-INF/web.xml");
+    public static final ArchivePath APPLICATION_XML_PATH = ArchivePaths.create("META-INF/application.xml");
+
+    private ServletUtil() {
+    }
+
+    public static URI determineBaseURI(ServletProtocolConfiguration config, HTTPContext context, String servletName) {
+        String scheme = config.getScheme();
+        String host = config.getHost();
+        Integer port = config.getPort();
+
+        // TODO: can not set contextRoot in config, change to prefixContextRoot
+        String contextRoot = null; //protocolConfiguration.getContextRoot();
+
+        Servlet servlet = context.getServletByName(servletName);
+        if (servlet != null) {
+            // use the context where the Arquillian servlet is found
+            if (scheme == null) {
+                scheme = "http";
+            }
+            if (host == null) {
+                host = context.getHost();
+            }
+            if (port == null) {
+                port = context.getPort();
+            }
+            contextRoot = servlet.getContextRoot();
+        } else {
+            throw new IllegalArgumentException(
+                servletName + " not found. " +
+                    "Could not determine ContextRoot from ProtocolMetadata, please contact DeployableContainer developer.");
+        }
+        return URI.create(scheme + "://" + host + ":" + port + contextRoot);
+    }
+
+    public static String calculateContextRoot(String archiveName) {
+        String correctedName = archiveName;
+        if (correctedName.startsWith("/")) {
+            correctedName = correctedName.substring(1);
+        }
+        if (correctedName.indexOf(".") != -1) {
+            correctedName = correctedName.substring(0, correctedName.lastIndexOf("."));
+        }
+        return correctedName;
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/api/application/ApplicationDescriptor.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/api/application/ApplicationDescriptor.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.application;
+
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+/**
+ * DSL Grammar to construct / alter Application XML Descriptors
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public interface ApplicationDescriptor extends Descriptor {
+
+    ApplicationDescriptor version(String version);
+
+    ApplicationDescriptor displayName(String displayName);
+
+    ApplicationDescriptor description(String description);
+
+    ApplicationDescriptor libraryDirectory(String libraryDirectory);
+
+    ApplicationDescriptor webModule(String uri, String contextRoot);
+
+    ApplicationDescriptor ejbModule(String uri);
+
+    ApplicationDescriptor javaModule(String uri);
+
+    ApplicationDescriptor connectorModule(String uri);
+
+    ApplicationDescriptor securityRole(String roleName);
+
+    ApplicationDescriptor securityRole(String roleName, String description);
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/api/application/WebModule.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/api/application/WebModule.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.application;
+
+/**
+ * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ */
+public interface WebModule {
+    String getUri();
+
+    void setUri(String uri);
+
+    String getContextRoot();
+
+    void setContextRoot(String contextRoot);
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/api/web/InitParamDef.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/api/web/InitParamDef.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.web;
+
+/**
+ * FilterDef
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public interface InitParamDef extends WebAppDescriptor {
+
+    InitParamDef initParam(String name, Object value);
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/api/web/ServletDef.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/api/web/ServletDef.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.web;
+
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ */
+public interface ServletDef extends WebAppDescriptor {
+    ServletDef name(String name);
+
+    ServletDef servletClass(Class<?> clazz);
+
+    ServletDef servletClass(String clazz);
+
+    ServletDef asyncSupported(boolean value);
+
+    ServletDef initParam(String name, Object value);
+
+    ServletDef loadOnStartup(int order);
+
+    ServletMappingDef mapping();
+
+    String getName();
+
+    String getServletClass();
+
+    String getInitParam(String name);
+
+    Map<String, String> getInitParams();
+
+    boolean isAsyncSupported();
+
+    int getLoadOnStartup();
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/api/web/ServletMappingDef.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/api/web/ServletMappingDef.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.web;
+
+import java.util.List;
+
+/**
+ * ServletMapping
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * @version $Revision: $
+ */
+public interface ServletMappingDef extends ServletDef {
+    String getServletName();
+
+    ServletMappingDef servletName(String servletName);
+
+    List<String> getUrlPatterns();
+
+    ServletMappingDef urlPattern(String urlPattern);
+
+    ServletMappingDef urlPatterns(String... urlPatterns);
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/api/web/WebAppDescriptor.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/api/web/WebAppDescriptor.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.web;
+
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+/**
+ * DSL Grammar to construct / alter Web Application XML Descriptors
+ *
+ * @author <a href="mailto:andrew.rubinger@jboss.org">ALR</a>
+ */
+public interface WebAppDescriptor extends Descriptor {
+
+    WebAppDescriptor version(String version);
+
+    WebAppDescriptor displayName(String displayName);
+
+    ServletDef servlet(String clazz, String... urlPatterns);
+
+    ServletDef servlet(String name, String clazz, String[] urlPatterns);
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/impl/application/ApplicationDescriptorImpl.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/impl/application/ApplicationDescriptorImpl.java
@@ -1,0 +1,186 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.impl.application;
+
+import org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.application.ApplicationDescriptor;
+import org.jboss.shrinkwrap.descriptor.spi.node.Node;
+import org.jboss.shrinkwrap.descriptor.spi.node.NodeDescriptorImplBase;
+
+/**
+ * ApplicationDescriptorImpl
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ApplicationDescriptorImpl extends NodeDescriptorImplBase implements ApplicationDescriptor {
+    // -------------------------------------------------------------------------------------||
+    // Instance Members -------------------------------------------------------------------||
+    // -------------------------------------------------------------------------------------||
+
+    private final Node model;
+
+    // -------------------------------------------------------------------------------------||
+    // Constructor ------------------------------------------------------------------------||
+    // -------------------------------------------------------------------------------------||
+
+    public ApplicationDescriptorImpl(String descriptorName) {
+        this(descriptorName, new Node("application")
+            .attribute("xmlns", "http://java.sun.com/xml/ns/javaee")
+            .attribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance"));
+
+        version("6");
+    }
+
+    public ApplicationDescriptorImpl(String descriptorName, Node model) {
+        super(descriptorName);
+        this.model = model;
+    }
+
+    // -------------------------------------------------------------------------------------||
+    // API --------------------------------------------------------------------------------||
+    // -------------------------------------------------------------------------------------||
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.shrinkwrap.descriptor.api.spec.ee.application.ApplicationDescriptor#description()
+     */
+    @Override
+    public ApplicationDescriptor description(String description) {
+        model.getOrCreate("description").text(description);
+        return this;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.shrinkwrap.descriptor.api.spec.ee.application.ApplicationDescriptor#displayName(java.lang.String)
+     */
+    @Override
+    public ApplicationDescriptor displayName(String displayName) {
+        model.getOrCreate("display-name").text(displayName);
+        return this;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see
+     * org.jboss.shrinkwrap.descriptor.api.spec.ee.application.ApplicationDescriptor#libraryDirectory(java.lang.String)
+     */
+    @Override
+    public ApplicationDescriptor libraryDirectory(String libraryDirectory) {
+        model.getOrCreate("library-directory").text(libraryDirectory);
+        return this;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.shrinkwrap.descriptor.api.spec.ee.application.ApplicationDescriptor#ejbModule(java.lang.String)
+     */
+    @Override
+    public ApplicationDescriptor ejbModule(String uri) {
+        model.createChild("module").createChild("ejb").text(uri);
+        return this;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.shrinkwrap.descriptor.api.spec.ee.application.ApplicationDescriptor#javaModule(java.lang.String)
+     */
+    @Override
+    public ApplicationDescriptor javaModule(String uri) {
+        model.createChild("module").createChild("java").text(uri);
+        return this;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see
+     * org.jboss.shrinkwrap.descriptor.api.spec.ee.application.ApplicationDescriptor#connectorModule(java.lang.String)
+     */
+    @Override
+    public ApplicationDescriptor connectorModule(String uri) {
+        model.createChild("module").createChild("connector").text(uri);
+        return this;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.shrinkwrap.descriptor.api.spec.ee.application.ApplicationDescriptor#webModule(java.lang.String,
+     * java.lang.String)
+     */
+    @Override
+    public ApplicationDescriptor webModule(String uri, String contextRoot) {
+        Node web = model.createChild("module").createChild("web");
+        web.createChild("web-uri").text(uri);
+        web.createChild("context-root").text(contextRoot);
+        return this;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.shrinkwrap.descriptor.api.spec.ee.application.ApplicationDescriptor#version(java.lang.String)
+     */
+    @Override
+    public ApplicationDescriptor version(String version) {
+        model.attribute("version", version);
+        return this;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.shrinkwrap.descriptor.api.spec.ee.application.ApplicationDescriptor#securityRole(java.lang.String)
+     */
+    @Override
+    public ApplicationDescriptor securityRole(String roleName) {
+        return securityRole(roleName, null);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.shrinkwrap.descriptor.api.spec.ee.application.ApplicationDescriptor#securityRole(java.lang.String,
+     * java.lang.String)
+     */
+    @Override
+    public ApplicationDescriptor securityRole(String roleName, String description) {
+        Node security = model.createChild("security-role");
+        if (roleName != null) {
+            security.createChild("role-name").text(roleName);
+        }
+        if (description != null) {
+            security.createChild("description").text(description);
+        }
+        return this;
+    }
+
+    // -------------------------------------------------------------------------------------||
+    // Required Implementations - NodeProviderImplBase ------------------------------------||
+    // -------------------------------------------------------------------------------------||
+
+    @Override
+    public Node getRootNode() {
+        return model;
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/impl/application/WebModuleImpl.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/impl/application/WebModuleImpl.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.impl.application;
+
+import org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.application.WebModule;
+
+/**
+ * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ */
+public class WebModuleImpl implements WebModule {
+    private String uri;
+    private String contextRoot;
+
+    public WebModuleImpl(String webUri, String contextRoot) {
+        uri = webUri;
+        this.contextRoot = contextRoot;
+    }
+
+    @Override
+    public String getUri() {
+        return uri;
+    }
+
+    @Override
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    @Override
+    public String getContextRoot() {
+        return contextRoot;
+    }
+
+    @Override
+    public void setContextRoot(String contextRoot) {
+        this.contextRoot = contextRoot;
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/impl/web/InitParamDefImpl.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/impl/web/InitParamDefImpl.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.impl.web;
+
+import org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.web.InitParamDef;
+import org.jboss.shrinkwrap.descriptor.spi.node.Node;
+
+/**
+ * @author Dan Allen
+ */
+// TODO could be generic since servlet can use it too
+public class InitParamDefImpl extends WebAppDescriptorImpl implements InitParamDef {
+    protected Node child;
+
+    public InitParamDefImpl(String descriptorName, Node webApp, Node child) {
+        super(descriptorName, webApp);
+        this.child = child;
+    }
+
+    /* (non-Javadoc)
+     * @see org.jboss.shrinkwrap.descriptor.api.spec.web.FilterDef#initParam(java.lang.String, java.lang.Object)
+     */
+    @Override
+    public InitParamDef initParam(String name, Object value) {
+        Node init = child.createChild("init-param");
+        init.createChild("param-name").text(name);
+        init.createChild("param-value").text(String.valueOf(value));
+        return this;
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/impl/web/ServletDefImpl.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/impl/web/ServletDefImpl.java
@@ -1,0 +1,130 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.impl.web;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.web.ServletDef;
+import org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.web.ServletMappingDef;
+import org.jboss.shrinkwrap.descriptor.spi.node.Node;
+
+/**
+ * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ */
+public class ServletDefImpl extends WebAppDescriptorImpl implements ServletDef {
+    private final Node servlet;
+
+    public ServletDefImpl(String descriptorName, Node webApp, Node servlet) {
+        super(descriptorName, webApp);
+        this.servlet = servlet;
+    }
+
+    @Override
+    public ServletDef name(String name) {
+        servlet.getOrCreate("servlet-name").text(name);
+        return this;
+    }
+
+    @Override
+    public ServletDef asyncSupported(boolean value) {
+        servlet.getOrCreate("async-supported").text(value);
+        return this;
+    }
+
+    @Override
+    public ServletDef initParam(String name, Object value) {
+        InitParamDefImpl param = new InitParamDefImpl(getDescriptorName(), getRootNode(), servlet);
+        param.initParam(name, value == null ? null : value.toString());
+        return this;
+    }
+
+    @Override
+    public ServletDef loadOnStartup(int order) {
+        servlet.getOrCreate("load-on-startup").text(order);
+        return this;
+    }
+
+    @Override
+    public ServletMappingDef mapping() {
+        Node mappingNode = getRootNode().createChild("servlet-mapping");
+        ServletMappingDef mapping = new ServletMappingDefImpl(getDescriptorName(), getRootNode(), servlet, mappingNode);
+        mapping.servletName(getName());
+        return mapping;
+    }
+
+    @Override
+    public ServletDef servletClass(Class<?> clazz) {
+        return servletClass(clazz.getName());
+    }
+
+    @Override
+    public ServletDef servletClass(String clazz) {
+        servlet.getOrCreate("servlet-class").text(clazz);
+        return this;
+    }
+
+    @Override
+    public String getServletClass() {
+        if (servlet.getSingle("servlet-class") != null) {
+            return servlet.getSingle("servlet-class").getText();
+        }
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return servlet.getTextValueForPatternName("servlet-name");
+    }
+
+    @Override
+    public String getInitParam(String name) {
+        Map<String, String> params = getInitParams();
+        for (Entry<String, String> e : params.entrySet()) {
+            if (e.getKey() != null && e.getKey().equals(name)) {
+                return e.getValue();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Map<String, String> getInitParams() {
+        Map<String, String> result = new HashMap<String, String>();
+        List<Node> params = servlet.get("init-param");
+        for (Node node : params) {
+            result.put(node.getTextValueForPatternName("param-name"), node.getTextValueForPatternName("param-value"));
+        }
+        return result;
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        return Strings.isTrue(servlet.getTextValueForPatternName("async-supported"));
+    }
+
+    @Override
+    public int getLoadOnStartup() throws NumberFormatException {
+        String tex = servlet.getTextValueForPatternName("load-on-startup");
+        return tex == null ? null : Integer.valueOf(tex);
+    }
+
+    public Node getNode() {
+        return servlet;
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/impl/web/ServletMappingDefImpl.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/impl/web/ServletMappingDefImpl.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.impl.web;
+
+import java.util.List;
+import org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.web.ServletMappingDef;
+import org.jboss.shrinkwrap.descriptor.spi.node.Node;
+
+/**
+ * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ */
+public class ServletMappingDefImpl extends ServletDefImpl implements ServletMappingDef {
+    private final Node mapping;
+
+    public ServletMappingDefImpl(String descriptorName, Node webApp, Node servletNode, Node mappingNode) {
+        super(descriptorName, webApp, servletNode);
+        this.mapping = mappingNode;
+    }
+
+    @Override
+    public String getServletName() {
+        return mapping.getTextValueForPatternName("servlet-name");
+    }
+
+    @Override
+    public ServletMappingDef servletName(String servletName) {
+        mapping.getOrCreate("servlet-name").text(servletName);
+        return this;
+    }
+
+    @Override
+    public List<String> getUrlPatterns() {
+        return mapping.getTextValuesForPatternName("url-pattern");
+    }
+
+    @Override
+    public ServletMappingDef urlPattern(String urlPattern) {
+        mapping.createChild("url-pattern").text(urlPattern);
+        return this;
+    }
+
+    @Override
+    public ServletMappingDef urlPatterns(String... urlPatterns) {
+        for (String string : urlPatterns) {
+            urlPattern(string);
+        }
+        return this;
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/impl/web/Strings.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/impl/web/Strings.java
@@ -1,0 +1,90 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.impl.web;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * String utilities.
+ *
+ * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ */
+public class Strings {
+    /**
+     * Capitalize the given String: "input" -> "Input"
+     */
+    public static String capitalize(final String input) {
+        if ((input == null) || (input.length() == 0)) {
+            return input;
+        }
+        return input.substring(0, 1).toUpperCase() + input.substring(1).toLowerCase();
+    }
+
+    public static String unquote(final String value) {
+        String result = null;
+        if (value != null) {
+            result = value.replaceAll("\"(.*)\"", "$1");
+        }
+        return result;
+    }
+
+    public static String enquote(final String value) {
+        String result = null;
+        if (value != null) {
+            result = "\"" + value + "\"";
+        }
+        return result;
+    }
+
+    public static String join(Collection<?> collection, String delimiter) {
+        StringBuffer buffer = new StringBuffer();
+        Iterator<?> iter = collection.iterator();
+        while (iter.hasNext()) {
+            buffer.append(iter.next());
+            if (iter.hasNext()) {
+                buffer.append(delimiter);
+            }
+        }
+        return buffer.toString();
+    }
+
+    public static boolean isNullOrEmpty(String string) {
+        return string == null || "".equals(string);
+    }
+
+    public static boolean isTrue(String value) {
+        return value == null ? false : "true".equalsIgnoreCase(value.trim());
+    }
+
+    public static boolean areEqual(String left, String right) {
+        if (left == null && right == null) {
+            return true;
+        } else if (left == null || right == null) {
+            return false;
+        }
+        return left.equals(right);
+    }
+
+    public static boolean areEqualTrimmed(String left, String right) {
+        if (left != null && right != null) {
+            return left.trim().equals(right.trim());
+        }
+        return areEqual(left, right);
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/impl/web/WebAppDescriptorImpl.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/arq514hack/descriptors/impl/web/WebAppDescriptorImpl.java
@@ -1,0 +1,120 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.impl.web;
+
+import org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.web.ServletDef;
+import org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.web.WebAppDescriptor;
+import org.jboss.shrinkwrap.descriptor.spi.node.Node;
+import org.jboss.shrinkwrap.descriptor.spi.node.NodeDescriptorImplBase;
+
+/**
+ * @author Dan Allen
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @author <a href="mailto:andrew.rubinger@jboss.org">ALR</a>
+ * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ */
+public class WebAppDescriptorImpl extends NodeDescriptorImplBase implements WebAppDescriptor {
+    // -------------------------------------------------------------------------------------||
+    // Class Members ----------------------------------------------------------------------||
+    // -------------------------------------------------------------------------------------||
+
+    // -------------------------------------------------------------------------------------||
+    // Instance Members -------------------------------------------------------------------||
+    // -------------------------------------------------------------------------------------||
+
+    private final Node model;
+
+    // -------------------------------------------------------------------------------------||
+    // Constructor ------------------------------------------------------------------------||
+    // -------------------------------------------------------------------------------------||
+
+    public WebAppDescriptorImpl(String descriptorName) {
+        this(descriptorName, new Node("web-app")
+            .attribute("xmlns", "http://java.sun.com/xml/ns/javaee")
+            .attribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")
+            .attribute("xsi:schemaLocation",
+                "http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"));
+        version("3.0");
+    }
+
+    public WebAppDescriptorImpl(String descriptorName, Node model) {
+        super(descriptorName);
+        this.model = model;
+    }
+
+    // -------------------------------------------------------------------------------------||
+    // API --------------------------------------------------------------------------------||
+    // -------------------------------------------------------------------------------------||
+
+    @Override
+    public WebAppDescriptor version(final String version) {
+        if (version == null || version.length() == 0) {
+            throw new IllegalArgumentException("Version must be specified");
+        }
+        model.attribute("xsi:schemaLocation",
+            "http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_" + version.replace(".", "_")
+                + ".xsd");
+        model.attribute("version", version);
+        return this;
+    }
+
+    @Override
+    public WebAppDescriptor displayName(String displayName) {
+        model.getOrCreate("display-name").text(displayName);
+        return this;
+    }
+
+    @Override
+    public ServletDef servlet(String clazz, String... urlPatterns) {
+        return servlet(getSimpleName(clazz), clazz, urlPatterns);
+    }
+
+    @Override
+    public ServletDef servlet(String name, String clazz, String[] urlPatterns) {
+        Node servletNode = model.createChild("servlet");
+        servletNode.createChild("servlet-name").text(name);
+        servletNode.createChild("servlet-class").text(clazz);
+        ServletDef servlet = new ServletDefImpl(getDescriptorName(), model, servletNode);
+
+        servlet.mapping().urlPatterns(urlPatterns);
+        return servlet;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.shrinkwrap.descriptor.spi.NodeProvider#getRootNode()
+     */
+    @Override
+    public Node getRootNode() {
+        return model;
+    }
+
+    // -------------------------------------------------------------------------------------||
+    // Internal Helper Methods ------------------------------------------------------------||
+    // -------------------------------------------------------------------------------------||
+
+    /*
+     * org.test.MyClass -> MyClass
+     */
+    private String getSimpleName(String fqcn) {
+        if (fqcn.indexOf('.') >= 0) {
+            return fqcn.substring(fqcn.lastIndexOf('.') + 1);
+        }
+        return fqcn;
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/runner/SecurityActions.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/runner/SecurityActions.java
@@ -1,0 +1,337 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.runner;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A set of privileged actions that are not to leak out
+ * of this package
+ *
+ * @version $Revision: $
+ */
+final class SecurityActions {
+
+    //-------------------------------------------------------------------------------||
+    // Constructor ------------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * No instantiation
+     */
+    private SecurityActions() {
+        throw new UnsupportedOperationException("No instantiation");
+    }
+
+    //-------------------------------------------------------------------------------||
+    // Utility Methods --------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * Obtains the Thread Context ClassLoader
+     */
+    static ClassLoader getThreadContextClassLoader() {
+        return AccessController.doPrivileged(GetTcclAction.INSTANCE);
+    }
+
+    static boolean isClassPresent(String name) {
+        try {
+            loadClass(name);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    static Class<?> loadClass(String className) {
+        try {
+            return Class.forName(className, true, getThreadContextClassLoader());
+        } catch (ClassNotFoundException e) {
+            try {
+                return Class.forName(className, true, SecurityActions.class.getClassLoader());
+            } catch (ClassNotFoundException e2) {
+                throw new RuntimeException("Could not load class " + className, e2);
+            }
+        }
+    }
+
+    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments,
+        final Class<T> expectedType) {
+        @SuppressWarnings("unchecked")
+        Class<T> implClass = (Class<T>) loadClass(className);
+        if (!expectedType.isAssignableFrom(implClass)) {
+            throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+        }
+        return newInstance(implClass, argumentTypes, arguments);
+    }
+
+    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments,
+        final Class<T> expectedType, ClassLoader classLoader) {
+        Class<?> clazz = null;
+        try {
+            clazz = Class.forName(className, false, classLoader);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not load class " + className, e);
+        }
+        Object obj = newInstance(clazz, argumentTypes, arguments);
+        try {
+            return expectedType.cast(obj);
+        } catch (Exception e) {
+            throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType, e);
+        }
+    }
+
+    /**
+     * Create a new instance by finding a constructor that matches the argumentTypes signature
+     * using the arguments for instantiation.
+     *
+     * @param implClass
+     *     Full classname of class to create
+     * @param argumentTypes
+     *     The constructor argument types
+     * @param arguments
+     *     The constructor arguments
+     *
+     * @return a new instance
+     *
+     * @throws IllegalArgumentException
+     *     if className, argumentTypes, or arguments are null
+     * @throws RuntimeException
+     *     if any exceptions during creation
+     * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+     * @author <a href="mailto:andrew.rubinger@jboss.org">ALR</a>
+     */
+    static <T> T newInstance(final Class<T> implClass, final Class<?>[] argumentTypes, final Object[] arguments) {
+        if (implClass == null) {
+            throw new IllegalArgumentException("ImplClass must be specified");
+        }
+        if (argumentTypes == null) {
+            throw new IllegalArgumentException("ArgumentTypes must be specified. Use empty array if no arguments");
+        }
+        if (arguments == null) {
+            throw new IllegalArgumentException("Arguments must be specified. Use empty array if no arguments");
+        }
+        final T obj;
+        try {
+            Constructor<T> constructor = getConstructor(implClass, argumentTypes);
+            if (!constructor.isAccessible()) {
+                constructor.setAccessible(true);
+            }
+            obj = constructor.newInstance(arguments);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create new instance of " + implClass, e);
+        }
+
+        return obj;
+    }
+
+    /**
+     * Obtains the Constructor specified from the given Class and argument types
+     *
+     * @throws NoSuchMethodException
+     */
+    static <T> Constructor<T> getConstructor(final Class<T> clazz, final Class<?>... argumentTypes)
+        throws NoSuchMethodException {
+        try {
+            return AccessController.doPrivileged(new PrivilegedExceptionAction<Constructor<T>>() {
+                public Constructor<T> run() throws NoSuchMethodException {
+                    return clazz.getDeclaredConstructor(argumentTypes);
+                }
+            });
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof NoSuchMethodException) {
+                throw (NoSuchMethodException) t;
+            } else {
+                // No other checked Exception thrown by Class.getConstructor
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    /**
+     * Set a single Field value
+     *
+     * @param target
+     *     The object to set it on
+     * @param fieldName
+     *     The field name
+     * @param value
+     *     The new value
+     */
+    public static void setFieldValue(final Class<?> source, final Object target, final String fieldName,
+        final Object value) throws NoSuchFieldException {
+        try {
+            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
+                @Override
+                public Void run() throws Exception {
+                    Field field = source.getDeclaredField(fieldName);
+                    if (!field.isAccessible()) {
+                        field.setAccessible(true);
+                    }
+                    field.set(target, value);
+                    return null;
+                }
+            });
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof NoSuchFieldException) {
+                throw (NoSuchFieldException) t;
+            } else {
+                // No other checked Exception thrown by Class.getConstructor
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    public static List<Field> getFieldsWithAnnotation(final Class<?> source,
+        final Class<? extends Annotation> annotationClass) {
+        List<Field> declaredAccessableFields = AccessController.doPrivileged(new PrivilegedAction<List<Field>>() {
+            public List<Field> run() {
+                List<Field> foundFields = new ArrayList<Field>();
+                Class<?> nextSource = source;
+                while (nextSource != Object.class) {
+                    for (Field field : nextSource.getDeclaredFields()) {
+                        if (field.isAnnotationPresent(annotationClass)) {
+                            if (!field.isAccessible()) {
+                                field.setAccessible(true);
+                            }
+                            foundFields.add(field);
+                        }
+                    }
+                    nextSource = nextSource.getSuperclass();
+                }
+                return foundFields;
+            }
+        });
+        return declaredAccessableFields;
+    }
+
+    public static List<Method> getMethodsWithAnnotation(final Class<?> source,
+        final Class<? extends Annotation> annotationClass) {
+        List<Method> declaredAccessableMethods = AccessController.doPrivileged(new PrivilegedAction<List<Method>>() {
+            public List<Method> run() {
+                List<Method> foundMethods = new ArrayList<Method>();
+                Class<?> nextSource = source;
+                while (nextSource != Object.class) {
+                    for (Method method : filterBridgeMethods(nextSource.getDeclaredMethods())) {
+                        if (method.isAnnotationPresent(annotationClass)) {
+                            if (!method.isAccessible()) {
+                                method.setAccessible(true);
+                            }
+                            foundMethods.add(method);
+                        }
+                    }
+                    nextSource = nextSource.getSuperclass();
+                }
+                return foundMethods;
+            }
+        });
+        return declaredAccessableMethods;
+    }
+
+    static String getProperty(final String key) {
+        try {
+            String value = AccessController.doPrivileged(new PrivilegedExceptionAction<String>() {
+                public String run() {
+                    return System.getProperty(key);
+                }
+            });
+            return value;
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof SecurityException) {
+                throw (SecurityException) t;
+            }
+            if (t instanceof NullPointerException) {
+                throw (NullPointerException) t;
+            } else if (t instanceof IllegalArgumentException) {
+                throw (IllegalArgumentException) t;
+            } else {
+                // No other checked Exception thrown by System.getProtocolProperty
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    private static Collection<Method> filterBridgeMethods(Method... declaredMethods) {
+        final List<Method> nonBridgeMethods = new ArrayList<Method>(declaredMethods.length);
+
+        for (Method declaredMethod : declaredMethods) {
+            if (!declaredMethod.isBridge()) {
+                nonBridgeMethods.add(declaredMethod);
+            }
+        }
+
+        return nonBridgeMethods;
+    }
+
+    //-------------------------------------------------------------------------------||
+    // Inner Classes ----------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * Single instance to get the TCCL
+     */
+    private enum GetTcclAction implements PrivilegedAction<ClassLoader>
+
+    {
+        INSTANCE;
+
+        public ClassLoader run() {
+            return Thread.currentThread().getContextClassLoader();
+        }
+
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/runner/ServletCommandService.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/runner/ServletCommandService.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.runner;
+
+import org.jboss.arquillian.container.test.spi.command.Command;
+import org.jboss.arquillian.container.test.spi.command.CommandService;
+
+/**
+ * ServletRemoteEventService
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ServletCommandService implements CommandService {
+    private static long TIMEOUT = 30000;
+
+    @SuppressWarnings("unchecked")
+    public <T> T execute(Command<T> command) {
+        String currentId = ServletTestRunner.currentCall.get();
+        ServletTestRunner.events.put(currentId, command);
+
+        long timeoutTime = System.currentTimeMillis() + TIMEOUT;
+        while (timeoutTime > System.currentTimeMillis()) {
+            Command<?> newCommand = ServletTestRunner.events.get(currentId);
+            if (newCommand != null) {
+                if (newCommand.getThrowable() != null) {
+                    throw new RuntimeException(newCommand.getThrowable());
+                }
+                if (newCommand.getResult() != null) {
+                    return (T) newCommand.getResult();
+                }
+            }
+            try {
+                Thread.sleep(100);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        throw new RuntimeException("No command response within timeout of " + TIMEOUT + " ms.");
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/runner/ServletContextRegistrar.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/runner/ServletContextRegistrar.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.runner;
+
+import jakarta.servlet.ServletContext;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.api.event.ManagerStarted;
+
+public class ServletContextRegistrar {
+
+    @Inject
+    @ApplicationScoped
+    private InstanceProducer<ServletContext> servletContextInstanceProducer;
+
+    public void registerServletContext(@Observes ManagerStarted managerStarted) {
+        servletContextInstanceProducer.set(ServletTestRunner.getCurrentServletContext());
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/runner/ServletContextResourceProvider.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/runner/ServletContextResourceProvider.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.runner;
+
+import java.lang.annotation.Annotation;
+import jakarta.servlet.ServletContext;
+import org.jboss.arquillian.container.test.impl.enricher.resource.OperatesOnDeploymentAwareProvider;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.api.ArquillianResource;
+
+/**
+ * ServletContextResourceProvider
+ *
+ * @author asotobu
+ */
+public class ServletContextResourceProvider extends OperatesOnDeploymentAwareProvider {
+
+    @Inject
+    Instance<ServletContext> servletContextInstance;
+
+    @Override
+    public boolean canProvide(Class<?> type) {
+        return jakarta.servlet.ServletContext.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public Object doLookup(ArquillianResource arquillianResource, Annotation... annotations) {
+        return servletContextInstance.get();
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/runner/ServletRemoteExtension.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/runner/ServletRemoteExtension.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.runner;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.container.test.spi.command.CommandService;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+/**
+ * ServletRemoteExtension
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ServletRemoteExtension implements RemoteLoadableExtension {
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(CommandService.class, ServletCommandService.class);
+        builder.service(ResourceProvider.class, ServletContextResourceProvider.class);
+        builder.observer(ServletContextRegistrar.class);
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/runner/ServletTestRunner.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/runner/ServletTestRunner.java
@@ -1,0 +1,212 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.runner;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.PrintWriter;
+import java.util.concurrent.ConcurrentHashMap;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jboss.arquillian.container.test.spi.TestRunner;
+import org.jboss.arquillian.container.test.spi.command.Command;
+import org.jboss.arquillian.container.test.spi.util.TestRunners;
+import org.jboss.arquillian.test.spi.TestResult;
+
+/**
+ * ServletTestRunner
+ * <p>
+ * The server side executor for the Servlet protocol impl.
+ * <p>
+ * Supports multiple output modes ("outputmode"):
+ * - html
+ * - serializedObject
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ServletTestRunner extends HttpServlet {
+    public static final String PARA_METHOD_NAME = "methodName";
+    public static final String PARA_CLASS_NAME = "className";
+    public static final String PARA_OUTPUT_MODE = "outputMode";
+    public static final String PARA_CMD_NAME = "cmd";
+    public static final String OUTPUT_MODE_SERIALIZED = "serializedObject";
+    public static final String OUTPUT_MODE_HTML = "html";
+    public static final String CMD_NAME_TEST = "test";
+    public static final String CMD_NAME_EVENT = "event";
+    private static final long serialVersionUID = 1L;
+    static ConcurrentHashMap<String, Command<?>> events;
+    static ThreadLocal<String> currentCall;
+    private static ThreadLocal<ServletContext> currentServletContext;
+
+    public static ServletContext getCurrentServletContext() {
+        return currentServletContext.get();
+    }
+
+    @Override
+    public void init() throws ServletException {
+        events = new ConcurrentHashMap<String, Command<?>>();
+        currentCall = new ThreadLocal<String>();
+        currentServletContext = new ThreadLocal<ServletContext>();
+    }
+
+    @Override
+    public void destroy() {
+        events.clear();
+        currentCall.remove();
+        currentServletContext.remove();
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        execute(request, response);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        execute(request, response);
+    }
+
+    protected void execute(HttpServletRequest request, HttpServletResponse response)
+        throws ServletException, IOException {
+        String outputMode = OUTPUT_MODE_HTML;
+        String cmd = CMD_NAME_TEST;
+        try {
+            String className = null;
+            String methodName = null;
+
+            if (request.getParameter(PARA_OUTPUT_MODE) != null) {
+                outputMode = request.getParameter(PARA_OUTPUT_MODE);
+            }
+            className = request.getParameter(PARA_CLASS_NAME);
+            if (className == null) {
+                throw new IllegalArgumentException(PARA_CLASS_NAME + " must be specified");
+            }
+            methodName = request.getParameter(PARA_METHOD_NAME);
+            if (methodName == null) {
+                throw new IllegalArgumentException(PARA_METHOD_NAME + " must be specified");
+            }
+
+            if (request.getParameter(PARA_CMD_NAME) != null) {
+                cmd = request.getParameter(PARA_CMD_NAME);
+            }
+
+            currentServletContext.set(getServletContext());
+            currentCall.set(className + methodName);
+
+            if (CMD_NAME_TEST.equals(cmd)) {
+                executeTest(response, outputMode, className, methodName);
+            } else if (CMD_NAME_EVENT.equals(cmd)) {
+                executeEvent(request, response, className, methodName);
+            } else {
+                throw new RuntimeException("Unknown value for parameter" + PARA_CMD_NAME + ": " + cmd);
+            }
+        } catch (Exception e) {
+            if (OUTPUT_MODE_SERIALIZED.equalsIgnoreCase(outputMode)) {
+                writeObject(createFailedResult(e), response);
+            } else {
+                response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+            }
+        } finally {
+            currentCall.remove();
+            currentServletContext.remove();
+        }
+    }
+
+    public void executeTest(HttpServletResponse response, String outputMode, String className, String methodName)
+        throws ClassNotFoundException, IOException {
+        Class<?> testClass = SecurityActions.getThreadContextClassLoader().loadClass(className);
+        TestRunner runner = TestRunners.getTestRunner();
+        TestResult testResult = runner.execute(testClass, methodName);
+        if (OUTPUT_MODE_SERIALIZED.equalsIgnoreCase(outputMode)) {
+            writeObject(testResult, response);
+        } else {
+            // TODO: implement a html view of the result
+            response.setContentType("text/html");
+            response.setStatus(HttpServletResponse.SC_OK);
+            PrintWriter writer = response.getWriter();
+            writer.write("<html>\n");
+            writer.write("<head><title>TCK Report</title></head>\n");
+            writer.write("<body>\n");
+            writer.write("<h2>Configuration</h2>\n");
+            writer.write("<table>\n");
+            writer.write("<tr>\n");
+            writer.write("<td><b>Method</b></td><td><b>Status</b></td>\n");
+            writer.write("</tr>\n");
+
+            writer.write("</table>\n");
+            writer.write("<h2>Tests</h2>\n");
+            writer.write("<table>\n");
+            writer.write("<tr>\n");
+            writer.write("<td><b>Method</b></td><td><b>Status</b></td>\n");
+            writer.write("</tr>\n");
+
+            writer.write("</table>\n");
+            writer.write("</body>\n");
+        }
+    }
+
+    public void executeEvent(HttpServletRequest request, HttpServletResponse response, String className,
+        String methodName)
+        throws ClassNotFoundException, IOException {
+        String eventKey = className + methodName;
+
+        if (request.getContentLength() > 0) {
+            response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+            ObjectInputStream input = new ObjectInputStream(new BufferedInputStream(request.getInputStream()));
+            Command<?> result = (Command<?>) input.readObject();
+
+            events.put(eventKey, result);
+        } else {
+            if (events.containsKey(eventKey) && events.get(eventKey).getResult() == null) {
+                response.setStatus(HttpServletResponse.SC_OK);
+                ObjectOutputStream output = new ObjectOutputStream(response.getOutputStream());
+                output.writeObject(events.remove(eventKey));
+                output.flush();
+                output.close();
+            } else {
+                response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+            }
+        }
+    }
+
+    private void writeObject(Object object, HttpServletResponse response) {
+        try {
+            // Set HttpServletResponse status BEFORE getting the output stream
+            response.setStatus(HttpServletResponse.SC_OK);
+            ObjectOutputStream oos = new ObjectOutputStream(response.getOutputStream());
+            oos.writeObject(object);
+            oos.flush();
+            oos.close();
+        } catch (Exception e) {
+            try {
+                response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+            } catch (Exception e2) {
+                throw new RuntimeException("Could not write to output", e2);
+            }
+        }
+    }
+
+    private TestResult createFailedResult(Throwable throwable) {
+        return TestResult.failed(throwable);
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/v_5/ProtocolDeploymentAppender.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/v_5/ProtocolDeploymentAppender.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.v_5;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.protocol.servlet5.runner.ServletRemoteExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ * ProtocolDeploymentAppender
+ * <p>
+ * DeploymentAppender to add required resources for the protocol servlet to run
+ * in container.
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ProtocolDeploymentAppender implements AuxiliaryArchiveAppender {
+    @Override
+    public JavaArchive createAuxiliaryArchive() {
+        // Load based on package to avoid ClassNotFoundException on HttpServlet when loading ServletTestRunner
+        return ShrinkWrap.create(JavaArchive.class, "arquillian-jakarta-servlet-protocol.jar")
+            .addPackage(ServletRemoteExtension.class.getPackage()) // servlet.runner
+            .addAsManifestResource(
+                "org/jboss/arquillian/protocol/servlet5/v_5/web-fragment.xml",
+                "web-fragment.xml")
+            .addAsServiceProvider(RemoteLoadableExtension.class, ServletRemoteExtension.class);
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/v_5/ServletProtocol.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/v_5/ServletProtocol.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.v_5;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentPackager;
+import org.jboss.arquillian.protocol.servlet5.BaseServletProtocol;
+
+/**
+ * ServletProtocol
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ */
+public class ServletProtocol extends BaseServletProtocol {
+    public static final String PROTOCOL_NAME = "Servlet 5.0";
+
+    @Override
+    protected String getProtocolName() {
+        return PROTOCOL_NAME;
+    }
+
+    /* (non-Javadoc)
+     * @see org.jboss.arquillian.spi.client.protocol.Protocol#getPackager()
+     */
+    @Override
+    public DeploymentPackager getPackager() {
+        return new ServletProtocolDeploymentPackager();
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/v_5/ServletProtocolDeploymentPackager.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/v_5/ServletProtocolDeploymentPackager.java
@@ -1,0 +1,160 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.v_5;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+import org.jboss.arquillian.container.spi.client.deployment.Validate;
+import org.jboss.arquillian.container.test.spi.TestDeployment;
+import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentPackager;
+import org.jboss.arquillian.container.test.spi.client.deployment.ProtocolArchiveProcessor;
+import org.jboss.arquillian.protocol.servlet5.Processor;
+import org.jboss.arquillian.protocol.servlet5.ServletUtil;
+import org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.application.ApplicationDescriptor;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.Filters;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+
+import static org.jboss.arquillian.protocol.servlet5.ServletUtil.APPLICATION_XML_PATH;
+
+/**
+ * ServletProtocolDeploymentPackager
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ServletProtocolDeploymentPackager implements DeploymentPackager {
+    /* (non-Javadoc)
+     * @see org.jboss.arquillian.spi.DeploymentPackager#generateDeployment(org.jboss.arquillian.spi.TestDeployment)
+     */
+    public Archive<?> generateDeployment(TestDeployment testDeployment, Collection<ProtocolArchiveProcessor> processors) {
+        JavaArchive protocol = new ProtocolDeploymentAppender().createAuxiliaryArchive();
+
+        Archive<?> applicationArchive = testDeployment.getApplicationArchive();
+        Collection<Archive<?>> auxiliaryArchives = testDeployment.getAuxiliaryArchives();
+
+        Processor processor = new Processor(testDeployment, processors);
+
+        if (Validate.isArchiveOfType(EnterpriseArchive.class, applicationArchive)) {
+            return handleArchive(applicationArchive.as(EnterpriseArchive.class), auxiliaryArchives, protocol, processor,
+                testDeployment);
+        }
+
+        if (Validate.isArchiveOfType(WebArchive.class, applicationArchive)) {
+            return handleArchive(applicationArchive.as(WebArchive.class), auxiliaryArchives, protocol, processor);
+        }
+
+        if (Validate.isArchiveOfType(JavaArchive.class, applicationArchive)) {
+            return handleArchive(applicationArchive.as(JavaArchive.class), auxiliaryArchives, protocol, processor);
+        }
+
+        throw new IllegalArgumentException(ServletProtocolDeploymentPackager.class.getName() +
+            " can not handle archive of type " + applicationArchive.getClass().getName());
+    }
+
+    private Archive<?> handleArchive(WebArchive applicationArchive, Collection<Archive<?>> auxiliaryArchives,
+        JavaArchive protocol, Processor processor) {
+        applicationArchive
+            .addAsLibraries(
+                auxiliaryArchives.toArray(new Archive<?>[0]));
+
+        // Can be null when reusing logic in EAR packaging
+        if (protocol != null) {
+            applicationArchive.addAsLibrary(protocol);
+        }
+        processor.process(applicationArchive);
+        return applicationArchive;
+    }
+
+    private Archive<?> handleArchive(JavaArchive applicationArchive, Collection<Archive<?>> auxiliaryArchives,
+        JavaArchive protocol, Processor processor) {
+        return handleArchive(
+            ShrinkWrap.create(WebArchive.class, "test-" + UUID.randomUUID().toString() + ".war")
+                .addAsLibrary(applicationArchive),
+            auxiliaryArchives,
+            protocol,
+            processor);
+    }
+
+    private Archive<?> handleArchive(EnterpriseArchive applicationArchive, Collection<Archive<?>> auxiliaryArchives,
+        JavaArchive protocol, Processor processor, TestDeployment testDeployment) {
+        Map<ArchivePath, Node> applicationArchiveWars = applicationArchive.getContent(Filters.include(".*\\.war"));
+        if (applicationArchiveWars.size() == 1) {
+            ArchivePath warPath = applicationArchiveWars.keySet().iterator().next();
+            try {
+                handleArchive(
+                    applicationArchive.getAsType(WebArchive.class, warPath),
+                    new ArrayList<Archive<?>>(),
+                    // reuse the War handling, but Auxiliary Archives should be added to the EAR, not the WAR
+                    protocol,
+                    processor);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Can not manipulate war's that are not of type " + WebArchive.class,
+                    e);
+            }
+        } else if (applicationArchiveWars.size() > 1) {
+            Archive<?> archiveToTest = testDeployment.getArchiveForEnrichment();
+            if (archiveToTest == null) {
+                throw new UnsupportedOperationException("Multiple WebArchives found in "
+                    + applicationArchive.getName()
+                    + ". Can not determine which to enrich");
+            } else if (!archiveToTest.getName().endsWith(".war")) {
+                //TODO: Removed throwing an exception when EJB modules are supported as well
+                throw new UnsupportedOperationException("Archive to test is not a WebArchive!");
+            } else {
+                handleArchive(
+                    archiveToTest.as(WebArchive.class),
+                    new ArrayList<Archive<?>>(),
+                    // reuse the War handling, but Auxiliary Archives should be added to the EAR, not the WAR
+                    protocol,
+                    processor);
+            }
+        } else {
+            // reuse handle(JavaArchive, ..) logic
+            Archive<?> wrappedWar = handleArchive(protocol, new ArrayList<Archive<?>>(), null, processor);
+            applicationArchive
+                .addAsModule(wrappedWar);
+
+            if (applicationArchive.contains(APPLICATION_XML_PATH)) {
+                ApplicationDescriptor applicationXml = Descriptors.importAs(ApplicationDescriptor.class).fromStream(
+                    applicationArchive.get(APPLICATION_XML_PATH).getAsset().openStream());
+
+                applicationXml.webModule(wrappedWar.getName(), ServletUtil.calculateContextRoot(wrappedWar.getName()));
+
+                // SHRINKWRAP-187, to eager on not allowing overrides, delete it first
+                applicationArchive.delete(APPLICATION_XML_PATH);
+                applicationArchive.setApplicationXML(
+                    new StringAsset(applicationXml.exportAsString()));
+            }
+        }
+
+        applicationArchive.addAsLibraries(
+            auxiliaryArchives.toArray(new Archive<?>[0]));
+
+        return applicationArchive;
+    }
+}

--- a/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/v_6/ServletProtocol.java
+++ b/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/v_6/ServletProtocol.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2022 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.v_6;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentPackager;
+import org.jboss.arquillian.protocol.servlet5.BaseServletProtocol;
+import org.jboss.arquillian.protocol.servlet5.v_5.ServletProtocolDeploymentPackager;
+
+/**
+ * ServletProtocol
+ *
+ * @author <a href="mailto:github@bychkov.name">Vladimir Bychkov</a>
+ */
+public class ServletProtocol extends BaseServletProtocol {
+    public static final String PROTOCOL_NAME = "Servlet 6.0";
+
+    @Override
+    protected String getProtocolName() {
+        return PROTOCOL_NAME;
+    }
+
+    /* (non-Javadoc)
+     * @see org.jboss.arquillian.spi.client.protocol.Protocol#getPackager()
+     */
+    @Override
+    public DeploymentPackager getPackager() {
+        return new ServletProtocolDeploymentPackager();
+    }
+}

--- a/protocols/servlet-jakarta/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/protocols/servlet-jakarta/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.arquillian.protocol.servlet5.ServletExtension

--- a/protocols/servlet-jakarta/src/main/resources/META-INF/services/org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.application.ApplicationDescriptor
+++ b/protocols/servlet-jakarta/src/main/resources/META-INF/services/org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.application.ApplicationDescriptor
@@ -1,0 +1,3 @@
+implClass=org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.impl.application.ApplicationDescriptorImpl
+importerClass=org.jboss.shrinkwrap.descriptor.spi.node.dom.XmlDomNodeDescriptorImporterImpl
+defaultName=application.xml

--- a/protocols/servlet-jakarta/src/main/resources/META-INF/services/org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.web.WebAppDescriptor
+++ b/protocols/servlet-jakarta/src/main/resources/META-INF/services/org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.web.WebAppDescriptor
@@ -1,0 +1,3 @@
+implClass=org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.impl.web.WebAppDescriptorImpl
+importerClass=org.jboss.shrinkwrap.descriptor.spi.node.dom.XmlDomNodeDescriptorImporterImpl
+defaultName=web.xml

--- a/protocols/servlet-jakarta/src/main/resources/org/jboss/arquillian/protocol/servlet5/v_5/web-fragment.xml
+++ b/protocols/servlet-jakarta/src/main/resources/org/jboss/arquillian/protocol/servlet5/v_5/web-fragment.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-fragment xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="3.0"
+    xmlns="http://java.sun.com/xml/ns/javaee"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+   http://java.sun.com/xml/ns/javaee/web-fragment_3_0.xsd">
+
+  <servlet>
+    <servlet-name>ArquillianServletRunnerEE9</servlet-name>
+    <servlet-class>org.jboss.arquillian.protocol.servlet5.runner.ServletTestRunner</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>ArquillianServletRunnerEE9</servlet-name>
+    <url-pattern>/ArquillianServletRunnerEE9</url-pattern>
+  </servlet-mapping>
+</web-fragment>

--- a/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/AbstractServerBase.java
+++ b/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/AbstractServerBase.java
@@ -1,0 +1,166 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.server.NetworkConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
+import org.jboss.arquillian.protocol.servlet5.runner.ServletTestRunner;
+import org.jboss.arquillian.protocol.servlet5.test.MockTestRunner;
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * AbstractServerBase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class AbstractServerBase {
+    Server server;
+
+    @Before
+    public void setup() throws Exception {
+        int port = getAvailableLocalPort();
+        server = new Server(port);
+
+        ServletContextHandler root = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        root.setContextPath("/arquillian-protocol");
+        root.addServlet(ServletTestRunner.class, ServletMethodExecutor.ARQUILLIAN_SERVLET_MAPPING);
+        server.setHandler(root);
+        server.start();
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        MockTestRunner.clear();
+        server.stop();
+    }
+
+    private int getAvailableLocalPort() throws IOException {
+        ServerSocket socket = null;
+        try {
+            socket = new ServerSocket(0);
+            return socket.getLocalPort();
+        } finally {
+            if (socket != null) {
+                socket.close();
+            }
+        }
+    }
+
+    protected Collection<HTTPContext> createContexts() {
+        List<HTTPContext> context = new ArrayList<HTTPContext>();
+        context.add(createContext());
+        return context;
+    }
+
+    protected HTTPContext createContext() {
+        URI baseURI = createBaseURL();
+        HTTPContext context = new HTTPContext(baseURI.getHost(), baseURI.getPort());
+        context.add(new Servlet(ServletMethodExecutor.ARQUILLIAN_SERVLET_NAME, baseURI.getPath()));
+        return context;
+    }
+
+    protected URI createBaseURL() {
+        NetworkConnector conn0 = (NetworkConnector) server.getConnectors()[0];
+        return URI.create("http://localhost:" + conn0.getPort() + "/arquillian-protocol");
+    }
+
+    protected URL createURL(String outputMode, String testClass, String methodName) {
+        StringBuilder url = new StringBuilder(createBaseURL().toASCIIString() + ServletMethodExecutor.ARQUILLIAN_SERVLET_MAPPING);
+        boolean first = true;
+        if (outputMode != null) {
+            if (first) {
+                first = false;
+                url.append("?");
+            } else {
+                url.append("&");
+            }
+            url.append(ServletTestRunner.PARA_OUTPUT_MODE).append("=").append(outputMode);
+        }
+        if (testClass != null) {
+            if (first) {
+                first = false;
+                url.append("?");
+            } else {
+                url.append("&");
+            }
+            url.append(ServletTestRunner.PARA_CLASS_NAME).append("=").append(testClass);
+        }
+        if (methodName != null) {
+            if (first) {
+                first = false;
+                url.append("?");
+            } else {
+                url.append("&");
+            }
+            url.append(ServletTestRunner.PARA_METHOD_NAME).append("=").append(methodName);
+        }
+
+        try {
+            return new URL(url.toString());
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create url", e);
+        }
+    }
+
+    public static class MockTestExecutor implements TestMethodExecutor, Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        public void invoke(Object... parameters) throws Throwable {
+        }
+
+        public String getMethodName() {
+            return getMethod().getName();
+        }
+
+        public Method getMethod() {
+            try {
+                return this.getClass().getMethod("getMethod");
+            } catch (Exception e) {
+                throw new RuntimeException("Could not find my own method ?? ");
+            }
+        }
+
+        public Object getInstance() {
+            return this;
+        }
+    }
+}

--- a/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/BaseServletProtocolTestCase.java
+++ b/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/BaseServletProtocolTestCase.java
@@ -1,0 +1,146 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * ServletProtocolTestCase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class BaseServletProtocolTestCase {
+    @Test
+    public void shouldFindTestServletInMetadata() throws Exception {
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+
+        HTTPContext testContext = new HTTPContext("127.0.0.1", 8080)
+            .add(new Servlet(ServletMethodExecutor.ARQUILLIAN_SERVLET_NAME, "test"));
+
+        Method testMethod = getTestMethod("testNoAnnotations");
+
+        ServletURIHandler handler = new ServletURIHandler(config, to(testContext));
+        URI result = handler.locateTestServlet(testMethod);
+
+        Assert.assertEquals("http://127.0.0.1:8080/test", result.toString());
+    }
+
+    @Test
+    public void shouldOverrideMetadata() throws Exception {
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+        config.setScheme("https");
+        config.setHost("10.10.10.1");
+        config.setPort(90);
+
+        HTTPContext testContext = new HTTPContext("127.0.0.1", 8080)
+            .add(new Servlet(ServletMethodExecutor.ARQUILLIAN_SERVLET_NAME, "test"));
+
+        Method testMethod = getTestMethod("testNoAnnotations");
+
+        ServletURIHandler handler = new ServletURIHandler(config, to(testContext));
+        URI result = handler.locateTestServlet(testMethod);
+
+        Assert.assertEquals("https://10.10.10.1:90/test", result.toString());
+    }
+
+    @Test
+    public void shouldMatchNamedTargetedContext() throws Exception {
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+
+        HTTPContext testContextOne = new HTTPContext("Y", "127.0.0.1", 8080)
+            .add(new Servlet(ServletMethodExecutor.ARQUILLIAN_SERVLET_NAME, "test"));
+
+        HTTPContext testContextTwo = new HTTPContext("X", "127.0.0.1", 8081)
+            .add(new Servlet(ServletMethodExecutor.ARQUILLIAN_SERVLET_NAME, "test"));
+
+        Method testMethod = getTestMethod("testTargeted");
+
+        ServletURIHandler handler = new ServletURIHandler(config, to(testContextOne, testContextTwo));
+        URI result = handler.locateTestServlet(testMethod);
+
+        Assert.assertEquals("http://127.0.0.1:8081/test", result.toString());
+    }
+
+    @Test
+    public void shouldOverrideMatchNamedTargetedContext() throws Exception {
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+        config.setScheme("https");
+        config.setHost("10.10.10.1");
+        config.setPort(90);
+
+        HTTPContext testContextOne = new HTTPContext("Y", "127.0.0.1", 8080)
+            .add(new Servlet(ServletMethodExecutor.ARQUILLIAN_SERVLET_NAME, "testY"));
+
+        HTTPContext testContextTwo = new HTTPContext("X", "127.0.0.1", 8081)
+            .add(new Servlet(ServletMethodExecutor.ARQUILLIAN_SERVLET_NAME, "testX"));
+
+        Method testMethod = getTestMethod("testTargeted");
+
+        ServletURIHandler handler = new ServletURIHandler(config, to(testContextOne, testContextTwo));
+        URI result = handler.locateTestServlet(testMethod);
+
+        Assert.assertEquals("https://10.10.10.1:90/testX", result.toString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionOnMissingNamedTargetedContext() throws Exception {
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+
+        HTTPContext testContextOne = new HTTPContext("Y", "127.0.0.1", 8080)
+            .add(new Servlet(ServletMethodExecutor.ARQUILLIAN_SERVLET_NAME, "test"));
+
+        Method testMethod = getTestMethod("testTargeted");
+
+        ServletURIHandler handler = new ServletURIHandler(config, to(testContextOne));
+        handler.locateTestServlet(testMethod);
+    }
+
+    private Collection<HTTPContext> to(HTTPContext... inputs) {
+        List<HTTPContext> contexts = new ArrayList<HTTPContext>();
+        Collections.addAll(contexts, inputs);
+        return contexts;
+    }
+
+    private Method getTestMethod(String methodName) throws Exception {
+        return getClass().getDeclaredMethod(methodName);
+    }
+
+
+   /*
+    * Methods used for ServletURIHandler HTTPContext lookups. 
+    */
+
+    @SuppressWarnings("unused")
+    private void testNoAnnotations() {
+    }
+
+    @TargetsContainer("X")
+    private void testTargeted() {
+    }
+}

--- a/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/ProtocolTestCase.java
+++ b/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/ProtocolTestCase.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5;
+
+import java.net.URL;
+import org.jboss.arquillian.protocol.servlet5.runner.ServletTestRunner;
+import org.jboss.arquillian.protocol.servlet5.test.MockTestRunner;
+import org.jboss.arquillian.protocol.servlet5.test.TestCommandCallback;
+import org.jboss.arquillian.test.spi.TestResult;
+import org.jboss.arquillian.test.spi.TestResult.Status;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * ProtocolTestCase
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ProtocolTestCase extends AbstractServerBase {
+
+    @Test
+    public void shouldReturnTestResult() throws Exception {
+        MockTestRunner.add(TestResult.passed());
+
+        ServletMethodExecutor executor = createExecutor();
+        TestResult result = executor.invoke(new MockTestExecutor());
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            MockTestRunner.wantedResults.getStatus(),
+            result.getStatus());
+
+        Assert.assertNull(
+            "No Exception should have been thrown",
+            result.getThrowable());
+    }
+
+    @Test
+    public void shouldUseLogicalMethodNameAndSupportUrlReservedCharactersInIt() throws Exception {
+        final String testMethodNameWithReservedUrlCharacters = "non standard!test&name";
+
+        MockTestRunner.add(TestResult.passed());
+
+        ServletMethodExecutor executor = createExecutor();
+        executor.invoke(new MockTestExecutor() {
+            @Override
+            public String getMethodName() {
+                return testMethodNameWithReservedUrlCharacters;
+            }
+        });
+
+        Assert.assertEquals(
+            "Should use the logical method name",
+            testMethodNameWithReservedUrlCharacters,
+            MockTestRunner.testRequests.get(0).getMethodName()
+        );
+    }
+
+    @Test
+    public void shouldReturnThrownException() throws Exception {
+        MockTestRunner.add(TestResult.failed(new Exception().fillInStackTrace()));
+
+        ServletMethodExecutor executor = createExecutor();
+        TestResult result = executor.invoke(new MockTestExecutor());
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            MockTestRunner.wantedResults.getStatus(),
+            result.getStatus());
+
+        Assert.assertNotNull(
+            "Exception should have been thrown",
+            result.getThrowable());
+    }
+
+    @Test
+    public void shouldReturnExceptionWhenMissingTestClassParameter() throws Exception {
+        URL url = createURL(ServletTestRunner.OUTPUT_MODE_SERIALIZED, null, null);
+        TestResult result = (TestResult) TestUtil.execute(url);
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            Status.FAILED,
+            result.getStatus());
+
+        Assert.assertTrue(
+            "No Exception should have been thrown",
+            result.getThrowable() instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void shouldReturnExceptionWhenMissingMethodParameter() throws Exception {
+        URL url = createURL(ServletTestRunner.OUTPUT_MODE_SERIALIZED, "org.my.test", null);
+        TestResult result = (TestResult) TestUtil.execute(url);
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            Status.FAILED,
+            result.getStatus());
+
+        Assert.assertTrue(
+            "No Exception should have been thrown",
+            result.getThrowable() instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void shouldReturnExceptionWhenErrorLoadingClass() throws Exception {
+        URL url = createURL(ServletTestRunner.OUTPUT_MODE_SERIALIZED, "org.my.test", "test");
+        TestResult result = (TestResult) TestUtil.execute(url);
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            Status.FAILED,
+            result.getStatus());
+
+        Assert.assertTrue(
+            "No Exception should have been thrown",
+            result.getThrowable() instanceof ClassNotFoundException);
+    }
+
+    protected ServletMethodExecutor createExecutor() {
+        return new ServletMethodExecutor(
+            new ServletProtocolConfiguration(),
+            createContexts(),
+            new TestCommandCallback());
+    }
+}

--- a/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/ServletCommandServiceTestCase.java
+++ b/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/ServletCommandServiceTestCase.java
@@ -1,0 +1,106 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5;
+
+import java.lang.reflect.Field;
+import org.jboss.arquillian.protocol.servlet5.runner.ServletCommandService;
+import org.jboss.arquillian.protocol.servlet5.test.MockTestRunner;
+import org.jboss.arquillian.protocol.servlet5.test.TestCommandCallback;
+import org.jboss.arquillian.protocol.servlet5.test.TestIntegerCommand;
+import org.jboss.arquillian.protocol.servlet5.test.TestStringCommand;
+import org.jboss.arquillian.test.spi.TestResult;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * ServletCommandServiceTestCase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ServletCommandServiceTestCase extends AbstractServerBase {
+    @Test
+    public void shouldBeAbleToTransfereCommand() throws Exception {
+        Object[] results = new Object[] {"Wee", 100};
+
+        MockTestRunner.add(TestResult.passed());
+        MockTestRunner.add(new TestStringCommand());
+        MockTestRunner.add(new TestIntegerCommand());
+
+        ServletMethodExecutor executor = new ServletMethodExecutor(
+            new ServletProtocolConfiguration(),
+            createContexts(),
+            new TestCommandCallback(results));
+
+        TestResult result = executor.invoke(new MockTestExecutor());
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            MockTestRunner.wantedResults.getStatus(),
+            result.getStatus());
+
+        Assert.assertNull(
+            "Exception should have been thrown",
+            result.getThrowable());
+
+        Assert.assertEquals(
+            "Should have returned command",
+            results[0],
+            MockTestRunner.commandResults.get(0));
+
+        Assert.assertEquals(
+            "Should have returned command",
+            results[1],
+            MockTestRunner.commandResults.get(1));
+    }
+
+    @Test
+    public void shouldDisableCommandService() throws Exception {
+        Field f = ServletCommandService.class.getDeclaredField("TIMEOUT");
+        f.setAccessible(true);
+        f.set(null, 500);
+
+        ServletProtocolConfiguration config = new ServletProtocolConfiguration();
+        config.setPullInMilliSeconds(0);
+
+        Object[] results = new Object[] {"Wee", 100};
+
+        MockTestRunner.add(TestResult.failed(null));
+        MockTestRunner.add(new TestStringCommand());
+
+        ServletMethodExecutor executor = new ServletMethodExecutor(
+            config,
+            createContexts(),
+            new TestCommandCallback(results));
+
+        TestResult result = executor.invoke(new MockTestExecutor());
+
+        Assert.assertEquals(
+            "Should have returned a passed test",
+            MockTestRunner.wantedResults.getStatus(),
+            result.getStatus());
+
+        Assert.assertNotNull(
+            "Exception should have been thrown",
+            result.getThrowable());
+
+        Assert.assertTrue(
+            "Timeout exception should have been thrown",
+            result.getThrowable().getMessage().contains("timeout"));
+    }
+}

--- a/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/TestUtil.java
+++ b/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/TestUtil.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.net.URL;
+
+/**
+ * TestUtil
+ * <p>
+ * Internal helper for testcase to do http request
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestUtil {
+    private TestUtil() {
+    }
+
+    public static Object execute(URL url) {
+        ObjectInputStream input = null;
+        try {
+            input = new ObjectInputStream(url.openStream());
+            return input.readObject();
+        } catch (Exception e) {
+            throw new RuntimeException("Could not fetch url " + url);
+        } finally {
+            close(input);
+        }
+    }
+
+    private static void close(InputStream input) {
+        if (input == null) {
+            return;
+        }
+        try {
+            input.close();
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
+    public static String convertToString(InputStream in) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int b;
+        while ((b = in.read()) != -1) {
+            out.write(b);
+        }
+        out.close();
+        in.close();
+        return new String(out.toByteArray(), "UTF-8");
+    }
+}

--- a/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/test/MockTestRunner.java
+++ b/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/test/MockTestRunner.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.test;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.jboss.arquillian.container.test.spi.TestRunner;
+import org.jboss.arquillian.container.test.spi.command.Command;
+import org.jboss.arquillian.protocol.servlet5.runner.ServletCommandService;
+import org.jboss.arquillian.test.spi.TestResult;
+
+/**
+ * MockTestRunner
+ * <p>
+ * TestRunner that will return what you want for testing
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class MockTestRunner implements TestRunner {
+    public static TestResult wantedResults;
+
+    public static List<Command<?>> commands = new ArrayList<Command<?>>();
+    public static List<Object> commandResults = new ArrayList<Object>();
+
+    public static List<TestRequest> testRequests = new ArrayList<TestRequest>();
+
+    public static void add(Command<?> command) {
+        commands.add(command);
+    }
+
+    public static void add(TestResult wantedTestResult) {
+        wantedResults = wantedTestResult;
+    }
+
+    public static void clear() {
+        wantedResults = null;
+        commands.clear();
+        commandResults.clear();
+        testRequests.clear();
+    }
+
+    public TestResult execute(Class<?> testClass, String methodName) {
+        testRequests.add(new TestRequest(testClass, methodName));
+        for (Command<?> command : commands) {
+            commandResults.add(new ServletCommandService().execute(command));
+        }
+
+        return wantedResults;
+    }
+
+    public static class TestRequest {
+        private final Class<?> testClass;
+        private final String methodName;
+
+        public TestRequest(Class<?> testClass, String methodName) {
+            this.testClass = testClass;
+            this.methodName = methodName;
+        }
+
+        public Class<?> getTestClass() {
+            return testClass;
+        }
+
+        public String getMethodName() {
+            return methodName;
+        }
+    }
+}

--- a/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/test/TestCommandCallback.java
+++ b/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/test/TestCommandCallback.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.test;
+
+import org.jboss.arquillian.container.test.spi.command.Command;
+import org.jboss.arquillian.container.test.spi.command.CommandCallback;
+
+/**
+ * TestRemoteCommandCallback
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestCommandCallback implements CommandCallback {
+    private Object[] results;
+
+    private int invocationCount = 0;
+
+    public TestCommandCallback(Object... object) {
+        results = object;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    public void fired(Command event) {
+        event.setResult(results[invocationCount++]);
+    }
+}

--- a/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/test/TestIntegerCommand.java
+++ b/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/test/TestIntegerCommand.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.test;
+
+import java.io.Serializable;
+import org.jboss.arquillian.container.test.spi.command.Command;
+
+/**
+ * TestRemoteCommand
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestIntegerCommand implements Command<Integer>, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Integer result;
+    private Throwable throwable;
+
+    @Override
+    public Integer getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(Integer result) {
+        this.result = result;
+    }
+
+    @Override
+    public Throwable getThrowable() {
+        return throwable;
+    }
+
+    @Override
+    public void setThrowable(Throwable throwable) {
+        this.throwable = throwable;
+    }
+}

--- a/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/test/TestStringCommand.java
+++ b/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/test/TestStringCommand.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.test;
+
+import java.io.Serializable;
+import org.jboss.arquillian.container.test.spi.command.Command;
+
+/**
+ * TestRemoteCommand
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class TestStringCommand implements Command<String>, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String result;
+    private Throwable throwable;
+
+    @Override
+    public String getResult() {
+        return result;
+    }
+
+    @Override
+    public void setResult(String result) {
+        this.result = result;
+    }
+
+    @Override
+    public Throwable getThrowable() {
+        return throwable;
+    }
+
+    @Override
+    public void setThrowable(Throwable throwable) {
+        this.throwable = throwable;
+    }
+}

--- a/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/v_5/ProtocolDeploymentAppenderTestCase.java
+++ b/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/v_5/ProtocolDeploymentAppenderTestCase.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.v_5;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * ProtocolDeploymentAppenderTestCase
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ProtocolDeploymentAppenderTestCase {
+
+    @Test
+    public void shouldGenerateDependencies() throws Exception {
+
+        Archive<?> archive = new ProtocolDeploymentAppender().createAuxiliaryArchive();
+
+        Assert.assertTrue(
+            "Should have added web.xml",
+            archive.contains(ArchivePaths.create("META-INF/web-fragment.xml"))
+        );
+
+        Assert.assertTrue(
+            "Should have added " + RemoteLoadableExtension.class.getName(),
+            archive.contains(ArchivePaths.create("META-INF/services/" + RemoteLoadableExtension.class.getName()))
+        );
+
+        System.out.println(archive.toString(true));
+    }
+}

--- a/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/v_5/ServletProtocolDeploymentPackagerTestCase.java
+++ b/protocols/servlet-jakarta/src/test/java/org/jboss/arquillian/protocol/servlet5/v_5/ServletProtocolDeploymentPackagerTestCase.java
@@ -1,0 +1,321 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.protocol.servlet5.v_5;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.jboss.arquillian.container.spi.client.deployment.Validate;
+import org.jboss.arquillian.container.test.api.Testable;
+import org.jboss.arquillian.container.test.spi.TestDeployment;
+import org.jboss.arquillian.container.test.spi.client.deployment.ProtocolArchiveProcessor;
+import org.jboss.arquillian.protocol.servlet5.TestUtil;
+import org.jboss.arquillian.protocol.servlet5.arq514hack.descriptors.api.application.ApplicationDescriptor;
+import org.jboss.arquillian.protocol.servlet5.runner.ServletTestRunner;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * ServletProtocolDeploymentPackagerTestCase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ServletProtocolDeploymentPackagerTestCase {
+    @Test
+    public void shouldHandleJavaArchive() throws Exception {
+        Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
+            new TestDeployment(
+                null,
+                ShrinkWrap.create(JavaArchive.class, "applicationArchive.jar"),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertTrue(
+            "Verify that a defined JavaArchive using EE6 JavaArchive protocol is build as WebArchive",
+            Validate.isArchiveOfType(WebArchive.class, archive));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/arquillian-jakarta-servlet-protocol.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/auxiliaryArchive2.jar")));
+
+        Assert.assertTrue(
+            "Verify that the applicationArchive is placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/applicationArchive.jar")));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test
+    public void shouldHandleWebArchive() throws Exception {
+        Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
+            new TestDeployment(
+                null,
+                ShrinkWrap.create(WebArchive.class, "applicationArchive.war"),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertTrue(
+            "Verify that a defined WebArchive using EE9 JavaArchive protocol is build as WebArchive",
+            Validate.isArchiveOfType(WebArchive.class, archive));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/arquillian-jakarta-servlet-protocol.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/auxiliaryArchive1.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /WEB-INF/lib",
+            archive.contains(ArchivePaths.create("/WEB-INF/lib/auxiliaryArchive2.jar")));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test
+    public void shouldHandleEnterpriseArchive() throws Exception {
+        Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
+            new TestDeployment(
+                null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear"),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /",
+            archive.contains(ArchivePaths.create(JarNameProcessor.jarName)));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive1.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive2.jar")));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test
+    public void shouldHandleEnterpriseArchiveWithApplicationXML() throws Exception {
+        Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
+            new TestDeployment(
+                null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
+                    .setApplicationXML(createApplicationDescriptor()),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /",
+            archive.contains(ArchivePaths.create(JarNameProcessor.jarName)));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive1.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive2.jar")));
+
+        String applicationXmlContent =
+            TestUtil.convertToString(archive.get("META-INF/application.xml").getAsset().openStream());
+        Assert.assertTrue(
+            "verify that the arquillian-jakarta-servlet-protocol.war was added to the application.xml",
+            applicationXmlContent.contains(String.format("<web-uri>%s</web-uri>", JarNameProcessor.jarName)));
+
+        // ARQ-670
+        Assert.assertTrue(
+            "verify that the arquillian-jakarta-servlet-protocol.war has correct context-root in application.xml",
+            applicationXmlContent.contains(String.format("<context-root>%s</context-root>",
+                    JarNameProcessor.jarName.replaceFirst(".war$", ""))));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test
+    public void shouldHandleEnterpriseArchiveWithWebArchive() throws Exception {
+        WebArchive applicationWar = ShrinkWrap.create(WebArchive.class, "applicationArchive.war");
+
+        Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
+            new TestDeployment(
+                null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
+                    .addAsModule(applicationWar),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertFalse(
+            "Verify that the auxiliaryArchives was not added",
+            archive.contains(ArchivePaths.create("arquillian-jakarta-servlet-protocol.war")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive1.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive2.jar")));
+
+        String webXmlContent = TestUtil.convertToString(
+            applicationWar.get("WEB-INF/lib/arquillian-jakarta-servlet-protocol.jar/META-INF/web-fragment.xml").getAsset().openStream());
+        Assert.assertTrue(
+            "verify that the ServletTestRunner servlet was added to the web.xml of the existing web archive",
+            webXmlContent.contains(ServletTestRunner.class.getName()));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionOnUnknownArchiveType() throws Exception {
+        new ServletProtocolDeploymentPackager().generateDeployment(
+            new TestDeployment(null, ShrinkWrap.create(ResourceAdapterArchive.class), new ArrayList<Archive<?>>()),
+            processors()
+        );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldThrowExceptionOnEnterpriseArchiveWithMultipleWebArchive() throws Exception {
+        new ServletProtocolDeploymentPackager().generateDeployment(
+            new TestDeployment(
+                null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
+                    .addAsModule(ShrinkWrap.create(WebArchive.class))
+                    .addAsModule(ShrinkWrap.create(WebArchive.class)),
+                createAuxiliaryArchives()),
+            processors());
+    }
+
+    @Test
+    public void shouldHandleEnterpriseArchiveWithMultipleWebArchiveAndOneMarkedWebArchive() throws Exception {
+        WebArchive testableArchive = Testable.archiveToTest(ShrinkWrap.create(WebArchive.class));
+
+        Archive<?> archive = new ServletProtocolDeploymentPackager().generateDeployment(
+            new TestDeployment(
+                null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
+                    .addAsModule(testableArchive)
+                    .addAsModule(ShrinkWrap.create(WebArchive.class)),
+                createAuxiliaryArchives()),
+            processors());
+
+        Assert.assertFalse(
+            "Verify that the auxiliaryArchives was not added",
+            archive.contains(ArchivePaths.create("arquillian-jakarta-servlet-protocol.war")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive1.jar")));
+
+        Assert.assertTrue(
+            "Verify that the auxiliaryArchives are placed in /lib",
+            archive.contains(ArchivePaths.create("/lib/auxiliaryArchive2.jar")));
+
+        String webXmlContent = TestUtil.convertToString(
+            testableArchive.get("WEB-INF/lib/arquillian-jakarta-servlet-protocol.jar/META-INF/web-fragment.xml").getAsset().openStream());
+        Assert.assertTrue(
+            "verify that the ServletTestRunner servlet was added to the web.xml of the existing web archive",
+            webXmlContent.contains(ServletTestRunner.class.getName()));
+
+        Assert.assertTrue(
+            "Verify protocol Processor SPI was called",
+            DummyProcessor.wasCalled);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldThrowExceptionOnEnterpriseArchiveWithMultipleMarkedWebArchives() throws Exception {
+        new ServletProtocolDeploymentPackager().generateDeployment(
+            new TestDeployment(
+                null,
+                ShrinkWrap.create(EnterpriseArchive.class, "applicationArchive.ear")
+                    .addAsModule(Testable.archiveToTest(ShrinkWrap.create(WebArchive.class)))
+                    .addAsModule(Testable.archiveToTest(ShrinkWrap.create(WebArchive.class))),
+                createAuxiliaryArchives()),
+            processors());
+    }
+
+    private Collection<Archive<?>> createAuxiliaryArchives() {
+        List<Archive<?>> archives = new ArrayList<Archive<?>>();
+        archives.add(ShrinkWrap.create(JavaArchive.class, "auxiliaryArchive1.jar"));
+        archives.add(ShrinkWrap.create(JavaArchive.class, "auxiliaryArchive2.jar"));
+
+        return archives;
+    }
+
+    private Asset createApplicationDescriptor() {
+        return new StringAsset(
+            Descriptors.create(ApplicationDescriptor.class)
+                .version("6")
+                .ejbModule("test.jar")
+                .exportAsString());
+    }
+
+    private Collection<ProtocolArchiveProcessor> processors() {
+        List<ProtocolArchiveProcessor> pros = new ArrayList<ProtocolArchiveProcessor>();
+        pros.add(new DummyProcessor());
+        pros.add(new JarNameProcessor());
+        return pros;
+    }
+
+    private static class DummyProcessor implements ProtocolArchiveProcessor {
+        public static boolean wasCalled = false;
+
+        public DummyProcessor() {
+            wasCalled = false;
+        }
+
+        @Override
+        public void process(TestDeployment testDeployment, Archive<?> protocolArchive) {
+            wasCalled = true;
+        }
+    }
+
+    private static class JarNameProcessor implements ProtocolArchiveProcessor {
+        static String jarName;
+
+        @Override
+        public void process(TestDeployment testDeployment, Archive<?> protocolArchive) {
+            jarName = protocolArchive.getName();
+        }
+    }
+}

--- a/protocols/servlet-jakarta/src/test/resources/META-INF/services/org.jboss.arquillian.container.test.spi.TestRunner
+++ b/protocols/servlet-jakarta/src/test/resources/META-INF/services/org.jboss.arquillian.container.test.spi.TestRunner
@@ -1,0 +1,1 @@
+org.jboss.arquillian.protocol.servlet5.test.MockTestRunner

--- a/protocols/servlet-jakarta/src/test/resources/test-web.xml
+++ b/protocols/servlet-jakarta/src/test/resources/test-web.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/javaee"
+    version="2.5"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+  <display-name>PackagingTestCase</display-name>
+  <servlet>
+    <servlet-name>TestServlet</servlet-name>
+    <servlet-class>org.jboss.arquillian.protocol.servlet_2_5.TestServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>TestServlet</servlet-name>
+    <url-pattern>/Test</url-pattern>
+  </servlet-mapping>
+</web-app>

--- a/testenrichers/cdi-jakarta/pom.xml
+++ b/testenrichers/cdi-jakarta/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <!-- Parent -->
+  <parent>
+    <groupId>org.jboss.arquillian.jakarta</groupId>
+    <artifactId>arquillian-parent-jakarta</artifactId>
+    <version>1.8.1.Final-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <!-- Model Version -->
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Artifact Configuration -->
+  <groupId>org.jboss.arquillian.testenricher</groupId>
+  <artifactId>arquillian-testenricher-cdi-jakarta</artifactId>
+  <name>Arquillian TestEnricher Jakarta CDI</name>
+  <description>Jakarta CDI TestEnricher for the Arquillian Project</description>
+
+
+  <!-- Properties -->
+  <properties>
+    <!-- Versioning -->
+    <version.weld-core>4.0.3.Final</version.weld-core>
+    <version.jakarta.cdi-api>3.0.0</version.jakarta.cdi-api>
+    <version.javax-el>2.2</version.javax-el>
+  </properties>
+
+  <!-- Dependencies -->
+  <dependencies>
+
+    <!-- org.jboss.arquillian -->
+    <dependency>
+      <groupId>org.jboss.arquillian.test</groupId>
+      <artifactId>arquillian-test-spi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-spi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
+      <version>${version.jakarta.cdi-api}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- test -->
+
+    <dependency>
+      <groupId>org.jboss.arquillian.test</groupId>
+      <artifactId>arquillian-test-impl-base</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.core</groupId>
+      <artifactId>arquillian-core-impl-base</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.core</groupId>
+      <artifactId>arquillian-core-impl-base</artifactId>
+      <version>${version.arquillian_core}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.test</groupId>
+      <artifactId>arquillian-test-impl-base</artifactId>
+      <version>${version.arquillian_core}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.shrinkwrap</groupId>
+      <artifactId>shrinkwrap-impl-base</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.weld.se</groupId>
+      <artifactId>weld-se-shaded</artifactId>
+      <version>${version.weld-core}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.el</groupId>
+      <artifactId>el-api</artifactId>
+      <version>${version.javax-el}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>
+

--- a/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/CDIInjectionEnricher.java
+++ b/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/CDIInjectionEnricher.java
@@ -1,0 +1,129 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi;
+
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.InjectionTarget;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.spi.TestEnricher;
+import org.jboss.arquillian.test.spi.annotation.TestScoped;
+
+/**
+ * Enricher that provide JSR-299 CDI class and method argument injection.
+ *
+ * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class CDIInjectionEnricher implements TestEnricher {
+    private static final String ANNOTATION_NAME = "jakarta.inject.Inject";
+
+    private static final Logger log = Logger.getLogger(TestEnricher.class.getName());
+
+    @Inject
+    private Instance<BeanManager> beanManagerInst;
+
+    @SuppressWarnings("rawtypes")
+    @Inject
+    @TestScoped // keep it raw, core does not like generics to much
+    private InstanceProducer<CreationalContext> creationalContextProducer;
+
+    /**
+     * @return the beanManagerInst
+     */
+    public BeanManager getBeanManager() {
+        return beanManagerInst.get();
+    }
+
+    @SuppressWarnings("unchecked")
+    public CreationalContext<Object> getCreationalContext() {
+        CreationalContext<Object> cc = creationalContextProducer.get();
+        if (cc == null) {
+            cc = getBeanManager().createCreationalContext(null);
+            creationalContextProducer.set(cc);
+        }
+        return cc;
+    }
+
+    /* (non-Javadoc)
+     * @see org.jboss.arquillian.spi.TestEnricher#enrich(org.jboss.arquillian.spi.Context, java.lang.Object)
+     */
+    public void enrich(Object testCase) {
+        if (SecurityActions.isClassPresent(ANNOTATION_NAME)) {
+            injectClass(testCase);
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see org.jboss.arquillian.spi.TestEnricher#resolve(org.jboss.arquillian.spi.Context, java.lang.reflect.Method)
+     */
+    public Object[] resolve(Method method) {
+        Object[] values = new Object[method.getParameterTypes().length];
+        if (SecurityActions.isClassPresent(ANNOTATION_NAME)) {
+            BeanManager beanManager = getBeanManager();
+            if (beanManager == null) {
+                return values;
+            }
+            Class<?>[] parameterTypes = method.getParameterTypes();
+            for (int i = 0; i < parameterTypes.length; i++) {
+                try {
+                    values[i] = getInstanceByType(beanManager, i, method);
+                } catch (Exception e) {
+                    log.fine("CDIEnricher tried to lookup method parameter of type "
+                        + parameterTypes[i]
+                        + " but caught exception: "
+                        + e.getMessage());
+                }
+            }
+        }
+        return values;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T getInstanceByType(BeanManager manager, final int position, final Method method) {
+        CreationalContext<?> cc = getCreationalContext();
+        return (T) manager.getInjectableReference(new MethodParameterInjectionPoint<T>(method, position, manager), cc);
+    }
+
+    protected void injectClass(Object testCase) {
+        try {
+            BeanManager beanManager = getBeanManager();
+            if (beanManager != null) {
+                injectNonContextualInstance(beanManager, testCase);
+            } else {
+                // Better would be to raise an exception if @Inject is present in class and BeanManager cannot be found
+                log.fine(
+                    "BeanManager cannot be located in context. Either you are using an archive with no beans.xml or the BeanManager has not been produced.");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Could not inject members", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void injectNonContextualInstance(BeanManager manager, Object instance) {
+        CreationalContext<Object> creationalContext = getCreationalContext();
+        InjectionTarget<Object> injectionTarget = (InjectionTarget<Object>) manager
+                .getInjectionTargetFactory(manager.createAnnotatedType(instance.getClass()))
+                .createInjectionTarget(null);
+        injectionTarget.inject(instance, creationalContext);
+    }
+}

--- a/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/CreationalContextDestroyer.java
+++ b/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/CreationalContextDestroyer.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.spi.EventContext;
+import org.jboss.arquillian.test.spi.event.suite.After;
+
+/**
+ * CreationalContextDestroyer
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class CreationalContextDestroyer {
+    @SuppressWarnings("rawtypes")
+    @Inject
+    private Instance<CreationalContext> creationalContext;
+
+    public void destory(@Observes EventContext<After> event) {
+        try {
+            event.proceed();
+        } finally {
+            CreationalContext<Object> cc = creationalContext.get();
+            if (cc != null) {
+                cc.release();
+            }
+        }
+    }
+}

--- a/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/MethodParameterInjectionPoint.java
+++ b/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/MethodParameterInjectionPoint.java
@@ -1,0 +1,182 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.spi.Annotated;
+import jakarta.enterprise.inject.spi.AnnotatedCallable;
+import jakarta.enterprise.inject.spi.AnnotatedParameter;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.util.AnnotationLiteral;
+
+/**
+ * MethodParameterInjectionPoint
+ *
+ * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
+ * @author Pete Muir
+ * @version $Revision: $
+ */
+public class MethodParameterInjectionPoint<T> implements InjectionPoint {
+    private Method method;
+    private int position;
+    private BeanManager beanManager;
+
+    public MethodParameterInjectionPoint(Method method, int position, BeanManager beanManager) {
+        this.method = method;
+        this.position = position;
+        this.beanManager = beanManager;
+    }
+
+    /* (non-Javadoc)
+     * @see jakarta.enterprise.inject.spi.InjectionPoint#getBean()
+     */
+    public Bean<?> getBean() {
+        return null;
+    }
+
+    /* (non-Javadoc)
+     * @see jakarta.enterprise.inject.spi.InjectionPoint#getMember()
+     */
+    public Member getMember() {
+        return method;
+    }
+
+    /* (non-Javadoc)
+     * @see jakarta.enterprise.inject.spi.InjectionPoint#getQualifiers()
+     */
+    public Set<Annotation> getQualifiers() {
+        Set<Annotation> qualifiers = new HashSet<Annotation>();
+        for (Annotation annotation : method.getParameterAnnotations()[position]) {
+            if (beanManager.isQualifier(annotation.annotationType())) {
+                qualifiers.add(annotation);
+            }
+        }
+
+        if (qualifiers.size() == 0) {
+            qualifiers.add(new DefaultLiteral());
+        }
+        return qualifiers;
+    }
+
+    /* (non-Javadoc)
+     * @see jakarta.enterprise.inject.spi.InjectionPoint#getType()
+     */
+    public Type getType() {
+        return findTypeOrGenericType();
+    }
+
+    /* (non-Javadoc)
+     * @see jakarta.enterprise.inject.spi.InjectionPoint#isDelegate()
+     */
+    public boolean isDelegate() {
+        return false;
+    }
+
+    /* (non-Javadoc)
+     * @see jakarta.enterprise.inject.spi.InjectionPoint#isTransient()
+     */
+    public boolean isTransient() {
+        return false;
+    }
+
+    /* (non-Javadoc)
+     * @see jakarta.enterprise.inject.spi.InjectionPoint#getAnnotated()
+     */
+    public Annotated getAnnotated() {
+        return new ArgumentAnnotated<T>();
+    }
+
+    private Type findTypeOrGenericType() {
+        if (method.getGenericParameterTypes().length > 0) {
+            return method.getGenericParameterTypes()[position];
+        }
+        return method.getParameterTypes()[position];
+    }
+
+    private static class DefaultLiteral extends AnnotationLiteral<Default> implements Default {
+        private static final long serialVersionUID = 1L;
+    }
+
+    private class ArgumentAnnotated<X> implements AnnotatedParameter<X> {
+
+        /* (non-Javadoc)
+         * @see jakarta.enterprise.inject.spi.AnnotatedParameter#getDeclaringCallable()
+         */
+        public AnnotatedCallable<X> getDeclaringCallable() {
+            return null;
+        }
+
+        /* (non-Javadoc)
+         * @see jakarta.enterprise.inject.spi.AnnotatedParameter#getPosition()
+         */
+        public int getPosition() {
+            return position;
+        }
+
+        /* (non-Javadoc)
+         * @see jakarta.enterprise.inject.spi.Annotated#getAnnotation(java.lang.Class)
+         */
+        public <Y extends Annotation> Y getAnnotation(Class<Y> annotationType) {
+            for (Annotation annotation : method.getParameterAnnotations()[position]) {
+                if (annotation.annotationType() == annotationType) {
+                    return annotationType.cast(annotation);
+                }
+            }
+            return null;
+        }
+
+        /* (non-Javadoc)
+         * @see jakarta.enterprise.inject.spi.Annotated#getAnnotations()
+         */
+        public Set<Annotation> getAnnotations() {
+            return new HashSet<Annotation>(Arrays.asList(method.getParameterAnnotations()[position]));
+        }
+
+        /* (non-Javadoc)
+         * @see jakarta.enterprise.inject.spi.Annotated#getBaseType()
+         */
+        public Type getBaseType() {
+            return getType();
+        }
+
+        /* (non-Javadoc)
+         * @see jakarta.enterprise.inject.spi.Annotated#getTypeClosure()
+         */
+        public Set<Type> getTypeClosure() {
+            Set<Type> types = new HashSet<Type>();
+            types.add(findTypeOrGenericType());
+            types.add(Object.class);
+            return types;
+        }
+
+        /* (non-Javadoc)
+         * @see jakarta.enterprise.inject.spi.Annotated#isAnnotationPresent(java.lang.Class)
+         */
+        public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
+            return getAnnotation(annotationType) != null;
+        }
+    }
+}

--- a/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/SecurityActions.java
+++ b/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/SecurityActions.java
@@ -1,0 +1,337 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A set of privileged actions that are not to leak out
+ * of this package
+ *
+ * @version $Revision: $
+ */
+final class SecurityActions {
+
+    //-------------------------------------------------------------------------------||
+    // Constructor ------------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * No instantiation
+     */
+    private SecurityActions() {
+        throw new UnsupportedOperationException("No instantiation");
+    }
+
+    //-------------------------------------------------------------------------------||
+    // Utility Methods --------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * Obtains the Thread Context ClassLoader
+     */
+    static ClassLoader getThreadContextClassLoader() {
+        return AccessController.doPrivileged(GetTcclAction.INSTANCE);
+    }
+
+    static boolean isClassPresent(String name) {
+        try {
+            loadClass(name);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    static Class<?> loadClass(String className) {
+        try {
+            return Class.forName(className, true, getThreadContextClassLoader());
+        } catch (ClassNotFoundException e) {
+            try {
+                return Class.forName(className, true, SecurityActions.class.getClassLoader());
+            } catch (ClassNotFoundException e2) {
+                throw new RuntimeException("Could not load class " + className, e2);
+            }
+        }
+    }
+
+    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments,
+        final Class<T> expectedType) {
+        @SuppressWarnings("unchecked")
+        Class<T> implClass = (Class<T>) loadClass(className);
+        if (!expectedType.isAssignableFrom(implClass)) {
+            throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+        }
+        return newInstance(implClass, argumentTypes, arguments);
+    }
+
+    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments,
+        final Class<T> expectedType, ClassLoader classLoader) {
+        Class<?> clazz = null;
+        try {
+            clazz = Class.forName(className, false, classLoader);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not load class " + className, e);
+        }
+        Object obj = newInstance(clazz, argumentTypes, arguments);
+        try {
+            return expectedType.cast(obj);
+        } catch (Exception e) {
+            throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType, e);
+        }
+    }
+
+    /**
+     * Create a new instance by finding a constructor that matches the argumentTypes signature
+     * using the arguments for instantiation.
+     *
+     * @param implClass
+     *     Full classname of class to create
+     * @param argumentTypes
+     *     The constructor argument types
+     * @param arguments
+     *     The constructor arguments
+     *
+     * @return a new instance
+     *
+     * @throws IllegalArgumentException
+     *     if className, argumentTypes, or arguments are null
+     * @throws RuntimeException
+     *     if any exceptions during creation
+     * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+     * @author <a href="mailto:andrew.rubinger@jboss.org">ALR</a>
+     */
+    static <T> T newInstance(final Class<T> implClass, final Class<?>[] argumentTypes, final Object[] arguments) {
+        if (implClass == null) {
+            throw new IllegalArgumentException("ImplClass must be specified");
+        }
+        if (argumentTypes == null) {
+            throw new IllegalArgumentException("ArgumentTypes must be specified. Use empty array if no arguments");
+        }
+        if (arguments == null) {
+            throw new IllegalArgumentException("Arguments must be specified. Use empty array if no arguments");
+        }
+        final T obj;
+        try {
+            Constructor<T> constructor = getConstructor(implClass, argumentTypes);
+            if (!constructor.isAccessible()) {
+                constructor.setAccessible(true);
+            }
+            obj = constructor.newInstance(arguments);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create new instance of " + implClass, e);
+        }
+
+        return obj;
+    }
+
+    /**
+     * Obtains the Constructor specified from the given Class and argument types
+     *
+     * @throws NoSuchMethodException
+     */
+    static <T> Constructor<T> getConstructor(final Class<T> clazz, final Class<?>... argumentTypes)
+        throws NoSuchMethodException {
+        try {
+            return AccessController.doPrivileged(new PrivilegedExceptionAction<Constructor<T>>() {
+                public Constructor<T> run() throws NoSuchMethodException {
+                    return clazz.getDeclaredConstructor(argumentTypes);
+                }
+            });
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof NoSuchMethodException) {
+                throw (NoSuchMethodException) t;
+            } else {
+                // No other checked Exception thrown by Class.getConstructor
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    /**
+     * Set a single Field value
+     *
+     * @param target
+     *     The object to set it on
+     * @param fieldName
+     *     The field name
+     * @param value
+     *     The new value
+     */
+    public static void setFieldValue(final Class<?> source, final Object target, final String fieldName,
+        final Object value) throws NoSuchFieldException {
+        try {
+            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
+                @Override
+                public Void run() throws Exception {
+                    Field field = source.getDeclaredField(fieldName);
+                    if (!field.isAccessible()) {
+                        field.setAccessible(true);
+                    }
+                    field.set(target, value);
+                    return null;
+                }
+            });
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof NoSuchFieldException) {
+                throw (NoSuchFieldException) t;
+            } else {
+                // No other checked Exception thrown by Class.getConstructor
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    public static List<Field> getFieldsWithAnnotation(final Class<?> source,
+        final Class<? extends Annotation> annotationClass) {
+        List<Field> declaredAccessableFields = AccessController.doPrivileged(new PrivilegedAction<List<Field>>() {
+            public List<Field> run() {
+                List<Field> foundFields = new ArrayList<Field>();
+                Class<?> nextSource = source;
+                while (nextSource != Object.class) {
+                    for (Field field : nextSource.getDeclaredFields()) {
+                        if (field.isAnnotationPresent(annotationClass)) {
+                            if (!field.isAccessible()) {
+                                field.setAccessible(true);
+                            }
+                            foundFields.add(field);
+                        }
+                    }
+                    nextSource = nextSource.getSuperclass();
+                }
+                return foundFields;
+            }
+        });
+        return declaredAccessableFields;
+    }
+
+    public static List<Method> getMethodsWithAnnotation(final Class<?> source,
+        final Class<? extends Annotation> annotationClass) {
+        List<Method> declaredAccessableMethods = AccessController.doPrivileged(new PrivilegedAction<List<Method>>() {
+            public List<Method> run() {
+                List<Method> foundMethods = new ArrayList<Method>();
+                Class<?> nextSource = source;
+                while (nextSource != Object.class) {
+                    for (Method method : filterBridgeMethods(nextSource.getDeclaredMethods())) {
+                        if (method.isAnnotationPresent(annotationClass)) {
+                            if (!method.isAccessible()) {
+                                method.setAccessible(true);
+                            }
+                            foundMethods.add(method);
+                        }
+                    }
+                    nextSource = nextSource.getSuperclass();
+                }
+                return foundMethods;
+            }
+        });
+        return declaredAccessableMethods;
+    }
+
+    static String getProperty(final String key) {
+        try {
+            String value = AccessController.doPrivileged(new PrivilegedExceptionAction<String>() {
+                public String run() {
+                    return System.getProperty(key);
+                }
+            });
+            return value;
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof SecurityException) {
+                throw (SecurityException) t;
+            }
+            if (t instanceof NullPointerException) {
+                throw (NullPointerException) t;
+            } else if (t instanceof IllegalArgumentException) {
+                throw (IllegalArgumentException) t;
+            } else {
+                // No other checked Exception thrown by System.getProtocolProperty
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    private static Collection<Method> filterBridgeMethods(Method... declaredMethods) {
+        final List<Method> nonBridgeMethods = new ArrayList<Method>(declaredMethods.length);
+
+        for (Method declaredMethod : declaredMethods) {
+            if (!declaredMethod.isBridge()) {
+                nonBridgeMethods.add(declaredMethod);
+            }
+        }
+
+        return nonBridgeMethods;
+    }
+
+    //-------------------------------------------------------------------------------||
+    // Inner Classes ----------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * Single instance to get the TCCL
+     */
+    private enum GetTcclAction implements PrivilegedAction<ClassLoader>
+
+    {
+        INSTANCE;
+
+        public ClassLoader run() {
+            return Thread.currentThread().getContextClassLoader();
+        }
+
+    }
+}

--- a/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/client/BeansXMLProtocolProcessor.java
+++ b/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/client/BeansXMLProtocolProcessor.java
@@ -1,0 +1,82 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi.client;
+
+import java.util.Map;
+import org.jboss.arquillian.container.spi.client.deployment.Validate;
+import org.jboss.arquillian.container.test.spi.TestDeployment;
+import org.jboss.arquillian.container.test.spi.client.deployment.ProtocolArchiveProcessor;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.Filters;
+import org.jboss.shrinkwrap.api.GenericArchive;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+/**
+ * A {@link ProtocolArchiveProcessor} that will add beans.xml to the protocol unit if one is defined in the test
+ * deployment.
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class BeansXMLProtocolProcessor implements ProtocolArchiveProcessor {
+    /* (non-Javadoc)
+     * @see org.jboss.arquillian.spi.client.deployment.ProtocolArchiveProcessor#process(org.jboss.arquillian.spi.TestDeployment, org.jboss.shrinkwrap.api.Archive)
+     */
+    @Override
+    public void process(TestDeployment testDeployment, Archive<?> protocolArchive) {
+        if (testDeployment.getApplicationArchive().equals(protocolArchive)) {
+            return; // if the protocol is merged in the user Archive, the user is in control.
+        }
+
+        if (containsBeansXML(testDeployment.getApplicationArchive())) {
+            if (Validate.isArchiveOfType(WebArchive.class, protocolArchive)) {
+                if (!protocolArchive.contains("WEB-INF/beans.xml")) {
+                    protocolArchive.as(WebArchive.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                }
+            } else if (Validate.isArchiveOfType(JavaArchive.class, protocolArchive)) {
+                if (!protocolArchive.contains("META-INF/beans.xml")) {
+                    protocolArchive.as(JavaArchive.class).addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                }
+            }
+        }
+    }
+
+    private boolean containsBeansXML(Archive<?> archive) {
+        Map<ArchivePath, Node> content = archive.getContent(Filters.include(".*/beans\\.xml"));
+        if (!content.isEmpty()) {
+            return true;
+        }
+        Map<ArchivePath, Node> nested = archive.getContent(Filters.include("/.*\\.(jar|war)"));
+        if (!nested.isEmpty()) {
+            for (ArchivePath path : nested.keySet()) {
+                try {
+                    if (containsBeansXML(archive.getAsType(GenericArchive.class, path))) {
+                        return true;
+                    }
+                } catch (IllegalArgumentException e) {
+                    // no-op, Nested archive is not a ShrinkWrap archive.
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/client/CDIEnricherArchiveAppender.java
+++ b/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/client/CDIEnricherArchiveAppender.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi.client;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.container.test.spi.client.deployment.CachedAuxilliaryArchiveAppender;
+import org.jboss.arquillian.testenricher.cdi.CDIInjectionEnricher;
+import org.jboss.arquillian.testenricher.cdi.container.CDIEnricherRemoteExtension;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ * CDIEnricherArchiveAppender
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class CDIEnricherArchiveAppender extends CachedAuxilliaryArchiveAppender {
+    @Override
+    protected Archive<?> buildArchive() {
+        return ShrinkWrap.create(JavaArchive.class, "arquillian-testenricher-cdi-jakarta.jar")
+            .addPackages(false,
+                CDIInjectionEnricher.class.getPackage(),
+                CDIEnricherRemoteExtension.class.getPackage())
+            // We can't use Extension.class, CDI API might not be available during package time
+            .addAsManifestResource(
+                new StringAsset("org.jboss.arquillian.testenricher.cdi.container.CDIExtension"),
+                "services/jakarta.enterprise.inject.spi.Extension")
+            .addAsServiceProvider(RemoteLoadableExtension.class, CDIEnricherRemoteExtension.class);
+    }
+}

--- a/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/client/CDIEnricherExtension.java
+++ b/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/client/CDIEnricherExtension.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi.client;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.container.test.spi.client.deployment.ProtocolArchiveProcessor;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.TestEnricher;
+import org.jboss.arquillian.testenricher.cdi.CDIInjectionEnricher;
+import org.jboss.arquillian.testenricher.cdi.CreationalContextDestroyer;
+
+/**
+ * CDIEnricherExtension
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class CDIEnricherExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(AuxiliaryArchiveAppender.class, CDIEnricherArchiveAppender.class)
+            .service(ProtocolArchiveProcessor.class, BeansXMLProtocolProcessor.class);
+
+        // only load if BeanManager is on ClassPath
+        if (Validate.classExists("jakarta.enterprise.inject.spi.BeanManager")) {
+            builder.service(TestEnricher.class, CDIInjectionEnricher.class);
+            builder.observer(CreationalContextDestroyer.class);
+        }
+    }
+}

--- a/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/container/BeanManagerProducer.java
+++ b/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/container/BeanManagerProducer.java
@@ -1,0 +1,77 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi.container;
+
+import java.util.logging.Logger;
+import jakarta.enterprise.inject.spi.BeanManager;
+import javax.naming.Context;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+
+/**
+ * BeanManagerLookup
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class BeanManagerProducer {
+    private static final String STANDARD_BEAN_MANAGER_JNDI_NAME = "java:comp/BeanManager";
+
+    private static final String SERVLET_BEAN_MANAGER_JNDI_NAME = "java:comp/env/BeanManager";
+
+    // TODO: Hack until BeanManager binding fixed in JBoss AS
+    private static final String JBOSSAS_BEAN_MANAGER_JNDI_NAME = "BeanManager";
+
+    private static final String[] BEAN_MANAGER_JNDI_NAMES =
+        {STANDARD_BEAN_MANAGER_JNDI_NAME, SERVLET_BEAN_MANAGER_JNDI_NAME, JBOSSAS_BEAN_MANAGER_JNDI_NAME};
+
+    private static final Logger log = Logger.getLogger(BeanManagerProducer.class.getName());
+
+    @Inject
+    @ApplicationScoped
+    private InstanceProducer<BeanManager> beanManagerProducer;
+
+    public void findBeanManager(@Observes Context context) {
+        BeanManager manager = lookup(context);
+        if (manager != null) {
+            beanManagerProducer.set(manager);
+        }
+    }
+
+    private BeanManager lookup(Context context) {
+        for (String beanManagerJndiName : BEAN_MANAGER_JNDI_NAMES) {
+            try {
+                return (BeanManager) context.lookup(beanManagerJndiName);
+            } catch (Exception e) {
+                log.fine("Tried to lookup the BeanManager with name " + beanManagerJndiName + " but caught exception: "
+                    + e.getMessage());
+            }
+        }
+
+        BeanManager beanManager = CDIExtension.getBeanManager();
+
+        if (beanManager != null) {
+            return beanManager;
+        }
+
+        log.info("BeanManager not found.");
+        return null;
+    }
+}

--- a/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/container/CDIEnricherRemoteExtension.java
+++ b/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/container/CDIEnricherRemoteExtension.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi.container;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.test.spi.TestEnricher;
+import org.jboss.arquillian.testenricher.cdi.CDIInjectionEnricher;
+import org.jboss.arquillian.testenricher.cdi.CreationalContextDestroyer;
+
+/**
+ * CDIEnricherRemoteExtension
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class CDIEnricherRemoteExtension implements RemoteLoadableExtension {
+    @Override
+    public void register(ExtensionBuilder builder) {
+        // only load if BeanManager is on ClassPath
+        if (Validate.classExists("jakarta.enterprise.inject.spi.BeanManager")) {
+            builder.service(TestEnricher.class, CDIInjectionEnricher.class);
+            builder.observer(BeanManagerProducer.class)
+                .observer(CreationalContextDestroyer.class);
+        }
+    }
+}

--- a/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/container/CDIExtension.java
+++ b/testenrichers/cdi-jakarta/src/main/java/org/jboss/arquillian/testenricher/cdi/container/CDIExtension.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi.container;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
+import jakarta.enterprise.inject.spi.BeforeShutdown;
+import jakarta.enterprise.inject.spi.Extension;
+
+public class CDIExtension implements Extension {
+    private static BeanManager beanManager;
+
+    public static BeanManager getBeanManager() {
+        return beanManager;
+    }
+
+    private static void setBeanManager(BeanManager beanManager) {
+        CDIExtension.beanManager = beanManager;
+    }
+
+    void beforeBeanDiscovery(@Observes BeforeBeanDiscovery beforeBeanDiscovery, BeanManager beanManager) {
+        setBeanManager(beanManager);
+    }
+
+    void beforeShutdown(@Observes BeforeShutdown beforeShutdown) {
+        setBeanManager(null);
+    }
+}

--- a/testenrichers/cdi-jakarta/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/testenrichers/cdi-jakarta/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.arquillian.testenricher.cdi.client.CDIEnricherExtension

--- a/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/BeansXMLProtocolProcessorTestCase.java
+++ b/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/BeansXMLProtocolProcessorTestCase.java
@@ -1,0 +1,167 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi;
+
+import java.io.BufferedInputStream;
+import java.util.ArrayList;
+import org.jboss.arquillian.container.test.spi.TestDeployment;
+import org.jboss.arquillian.testenricher.cdi.client.BeansXMLProtocolProcessor;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * BeansXMLProtocolProcessorTestCase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class BeansXMLProtocolProcessorTestCase {
+
+    @Test
+    public void shouldAddBeansXMLWhenFoundInWebArchive() {
+        WebArchive deployment = ShrinkWrap.create(WebArchive.class)
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        runAndAssertWebArchiveProtocol(deployment, true);
+    }
+
+    @Test
+    public void shouldAddBeansXMLWhenFoundInJavaArchive() {
+        JavaArchive deployment = ShrinkWrap.create(JavaArchive.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        runAndAssertJavaArchiveProtocol(deployment, true);
+    }
+
+    @Test
+    public void shouldNotAddBeansXMLIfNotFoundInWebArchive() {
+        WebArchive deployment = ShrinkWrap.create(WebArchive.class);
+
+        runAndAssertWebArchiveProtocol(deployment, false);
+    }
+
+    @Test
+    public void shouldAddBeansXMLWhenFoundInEnterpriseModule() {
+        EnterpriseArchive deployment = ShrinkWrap.create(EnterpriseArchive.class).addAsModule(
+            ShrinkWrap.create(WebArchive.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml"));
+
+        runAndAssertWebArchiveProtocol(deployment, true);
+    }
+
+    @Test
+    public void shouldNotAddBeansXMLIfNotFoundInEnterpriseModule() {
+        EnterpriseArchive deployment = ShrinkWrap.create(EnterpriseArchive.class).addAsModule(
+            ShrinkWrap.create(WebArchive.class));
+
+        runAndAssertWebArchiveProtocol(deployment, false);
+    }
+
+    @Test
+    public void shouldNotAddBeansXMLIfArchivesAreEqual() {
+        WebArchive protocol = ShrinkWrap.create(WebArchive.class);
+
+        new BeansXMLProtocolProcessor().process(
+            new TestDeployment(null, protocol, new ArrayList<Archive<?>>()), protocol);
+
+        Assert.assertFalse(protocol.contains("WEB-INF/beans.xml"));
+    }
+
+    @Test // ARQ-1421 this does not fail on SW 1.0 since it silently ignore overwriting existing paths.
+    public void shouldNotOverwriteBeansXMLIfArchivesAreTheSameAndContainBeansXml() throws Exception {
+        String beansXmlContent = "test";
+        WebArchive deployment = ShrinkWrap.create(WebArchive.class)
+            .addAsWebInfResource(new StringAsset(beansXmlContent), "beans.xml");
+
+        WebArchive protocol = deployment.as(WebArchive.class);
+
+        new BeansXMLProtocolProcessor().process(
+            new TestDeployment(null, deployment, new ArrayList<Archive<?>>()), protocol);
+
+        Assert.assertTrue(protocol.contains("WEB-INF/beans.xml"));
+
+        byte[] buf = new byte[beansXmlContent.length()];
+        new BufferedInputStream(protocol.get("WEB-INF/beans.xml").getAsset().openStream()).read(buf);
+
+        Assert.assertEquals(beansXmlContent, new String(buf));
+    }
+
+    @Test // ARQ-1421
+    public void shouldNotOverwriteBeansXMLIfProtocolWebArchiveContainBeansXml() throws Exception {
+        String beansXmlContent = "test";
+        WebArchive deployment = ShrinkWrap.create(WebArchive.class)
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        WebArchive protocol = ShrinkWrap.create(WebArchive.class)
+            .addAsWebInfResource(new StringAsset(beansXmlContent), "beans.xml");
+
+        new BeansXMLProtocolProcessor().process(
+            new TestDeployment(null, deployment, new ArrayList<Archive<?>>()), protocol);
+
+        Assert.assertTrue(protocol.contains("WEB-INF/beans.xml"));
+
+        byte[] buf = new byte[beansXmlContent.length()];
+        new BufferedInputStream(protocol.get("WEB-INF/beans.xml").getAsset().openStream()).read(buf);
+
+        Assert.assertEquals(beansXmlContent, new String(buf));
+    }
+
+    @Test // ARQ-1421
+    public void shouldNotOverwriteBeansXMLIfProtocolJavaArchiveContainBeansXml() throws Exception {
+        String beansXmlContent = "test";
+        JavaArchive deployment = ShrinkWrap.create(JavaArchive.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        JavaArchive protocol = ShrinkWrap.create(JavaArchive.class)
+            .addAsManifestResource(new StringAsset(beansXmlContent), "beans.xml");
+
+        new BeansXMLProtocolProcessor().process(
+            new TestDeployment(null, deployment, new ArrayList<Archive<?>>()), protocol);
+
+        Assert.assertTrue(protocol.contains("META-INF/beans.xml"));
+
+        byte[] buf = new byte[beansXmlContent.length()];
+        new BufferedInputStream(protocol.get("META-INF/beans.xml").getAsset().openStream()).read(buf);
+
+        Assert.assertEquals(beansXmlContent, new String(buf));
+    }
+
+    public void runAndAssertWebArchiveProtocol(Archive<?> deployment, boolean shouldBeFound) {
+        runAndAsset(deployment, ShrinkWrap.create(WebArchive.class), shouldBeFound, "WEB-INF/beans.xml");
+    }
+
+    public void runAndAssertJavaArchiveProtocol(Archive<?> deployment, boolean shouldBeFound) {
+        runAndAsset(deployment, ShrinkWrap.create(JavaArchive.class), shouldBeFound, "META-INF/beans.xml");
+    }
+
+    public void runAndAsset(Archive<?> deployment, Archive<?> protocol, boolean shouldBeFound, String expectedLocation) {
+        new BeansXMLProtocolProcessor().process(
+            new TestDeployment(null, deployment, new ArrayList<Archive<?>>()), protocol);
+
+        System.out.println(protocol.toString(true));
+        Assert.assertEquals(
+            "Verify beans.xml was " + (!shouldBeFound ? "not " : "") + "found in " + expectedLocation,
+            shouldBeFound, protocol.contains(expectedLocation));
+    }
+}

--- a/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/CDIInjectionEnricherTestCase.java
+++ b/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/CDIInjectionEnricherTestCase.java
@@ -1,0 +1,148 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import jakarta.enterprise.event.Event;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import org.jboss.arquillian.core.api.Injector;
+import org.jboss.arquillian.test.spi.annotation.TestScoped;
+import org.jboss.arquillian.test.test.AbstractTestTestBase;
+import org.jboss.arquillian.testenricher.cdi.beans.Cat;
+import org.jboss.arquillian.testenricher.cdi.beans.CatService;
+import org.jboss.arquillian.testenricher.cdi.beans.Dog;
+import org.jboss.arquillian.testenricher.cdi.beans.DogService;
+import org.jboss.arquillian.testenricher.cdi.beans.Service;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CDIInjectionEnricherTestCase extends AbstractTestTestBase {
+    private SeContainer container;
+    private BeanManager manager;
+    private CDIInjectionEnricher enricher;
+
+    @org.jboss.arquillian.core.api.annotation.Inject
+    private org.jboss.arquillian.core.api.Instance<Injector> injector;
+
+    @Override
+    protected void addExtensions(List<Class<?>> extensions) {
+        extensions.add(CreationalContextDestroyer.class);
+    }
+
+    @Before
+    public void setup() throws Exception {
+        container = SeContainerInitializer.newInstance()
+            .addBeanClasses(Service.class, Cat.class, CatService.class, Dog.class, DogService.class).initialize();
+        manager = container.getBeanManager();
+
+        bind(TestScoped.class, BeanManager.class, manager);
+
+        enricher = new CDIInjectionEnricher();
+        injector.get().inject(enricher);
+    }
+
+    @After
+    public void teardown() throws Exception {
+        container.close();
+    }
+
+    @Test
+    public void shouldInjectClassMembers() throws Exception {
+        TestClass testClass = new TestClass();
+        enricher.injectClass(testClass);
+        testClass.testMethod(testClass.dogService, testClass.catService);
+    }
+
+    @Test
+    public void shouldInjectMethodArguments() throws Exception {
+        Method testMethod = TestClass.class.getMethod("testMethod", Service.class, Service.class);
+
+        Object[] resolvedBeans = enricher.resolve(testMethod);
+
+        TestClass testClass = new TestClass();
+        testMethod.invoke(testClass, resolvedBeans);
+    }
+
+    @Test
+    public void shouldInjectMethodArgumentsEvent() throws Exception {
+        Method testMethod = TestClass.class.getMethod("testEvent", Event.class, Event.class);
+
+        Object[] resolvedBeans = enricher.resolve(testMethod);
+
+        TestClass testClass = new TestClass();
+        testMethod.invoke(testClass, resolvedBeans);
+    }
+
+    @Test
+    public void shouldReleaseCreationalContext() throws Exception {
+        TestClass testClass = new TestClass();
+        enricher.injectClass(testClass);
+
+        fire(new org.jboss.arquillian.test.spi.event.suite.After(this, TestClass.class.getMethod("validateReleased")));
+        testClass.validateReleased();
+    }
+
+    @Test
+    public void shouldInjectMethodArgumentsInstance() throws Exception {
+        Method testMethod = TestClass.class.getMethod("testInstance", Instance.class, Instance.class);
+
+        Object[] resolvedBeans = enricher.resolve(testMethod);
+
+        TestClass testClass = new TestClass();
+        testMethod.invoke(testClass, resolvedBeans);
+    }
+
+    private static class TestClass {
+        @Inject
+        Service<Dog> dogService;
+
+        @Inject
+        Service<Cat> catService;
+
+        public void validateReleased() {
+            Assert.assertTrue("@PreDestory has been called", dogService.wasReleased());
+            Assert.assertTrue("@PreDestory has been called", catService.wasReleased());
+        }
+
+        public void testMethod(Service<Dog> dogService, Service<Cat> catService) {
+            Assert.assertNotNull(catService);
+            Assert.assertNotNull(dogService);
+
+            Assert.assertEquals("Injected object should be of type", CatService.class, catService.getClass());
+            Assert.assertEquals("Injected object should be of type", DogService.class, dogService.getClass());
+        }
+
+        @SuppressWarnings("unused") // used only via reflection
+        public void testEvent(Event<Dog> dogEvent, Event<Cat> catEvent) {
+            Assert.assertNotNull("Generic Event should be injected as MethodArgument", dogEvent);
+            Assert.assertNotNull("Generic Event should be injected as MethodArgument", catEvent);
+        }
+
+        @SuppressWarnings("unused") // used only via reflection
+        public void testInstance(Instance<Dog> dogEvent, Instance<Cat> catEvent) {
+            Assert.assertNotNull("Generic Instance should be injected as MethodArgument", dogEvent);
+            Assert.assertNotNull("Generic Instance should be injected as MethodArgument", catEvent);
+        }
+    }
+}

--- a/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/beans/AbstractService.java
+++ b/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/beans/AbstractService.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi.beans;
+
+import jakarta.annotation.PreDestroy;
+
+/**
+ * AbstractService
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class AbstractService<T> implements Service<T> {
+    private boolean released = false;
+
+    @PreDestroy
+    public void release() {
+        this.released = true;
+    }
+
+    public boolean wasReleased() {
+        return released;
+    }
+}

--- a/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/beans/Cat.java
+++ b/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/beans/Cat.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi.beans;
+
+public class Cat {
+
+}

--- a/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/beans/CatService.java
+++ b/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/beans/CatService.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi.beans;
+
+public class CatService extends AbstractService<Cat> {
+
+}

--- a/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/beans/Dog.java
+++ b/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/beans/Dog.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi.beans;
+
+public class Dog {
+
+}

--- a/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/beans/DogService.java
+++ b/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/beans/DogService.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi.beans;
+
+public class DogService extends AbstractService<Dog> {
+
+}

--- a/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/beans/Service.java
+++ b/testenrichers/cdi-jakarta/src/test/java/org/jboss/arquillian/testenricher/cdi/beans/Service.java
@@ -1,0 +1,23 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.cdi.beans;
+
+public interface Service<T> {
+    boolean wasReleased();
+
+    void release();
+}

--- a/testenrichers/ejb-jakarta/pom.xml
+++ b/testenrichers/ejb-jakarta/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <!-- Parent -->
+  <parent>
+    <groupId>org.jboss.arquillian.jakarta</groupId>
+    <artifactId>arquillian-parent-jakarta</artifactId>
+    <version>1.8.1.Final-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <!-- Model Version -->
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Artifact Configuration -->
+  <groupId>org.jboss.arquillian.testenricher</groupId>
+  <artifactId>arquillian-testenricher-ejb-jakarta</artifactId>
+  <name>Arquillian TestEnricher Jakarta EJB</name>
+  <description>Jakarta EJB TestEnricher for the Arquillian Project</description>
+
+
+  <!-- Properties -->
+  <properties>
+    <!-- Versioning -->
+    <version.ejb.api.version>4.0.1</version.ejb.api.version>
+
+  </properties>
+
+  <!-- Dependencies -->
+  <dependencies>
+
+    <!-- org.jboss.arquillian -->
+    <dependency>
+      <groupId>org.jboss.arquillian.test</groupId>
+      <artifactId>arquillian-test-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-spi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.shrinkwrap</groupId>
+      <artifactId>shrinkwrap-impl-base</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <!--
+      Compile  run tests under EJB 4.0
+
+      Re-execute Maven with a new profile in the test phase.
+  -->
+  <profiles>
+    <profile>
+      <id>ejb40</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>jakarta.ejb</groupId>
+          <artifactId>jakarta.ejb-api</artifactId>
+          <version>${version.ejb.api.version}</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <reportsDirectory>${project.build.directory}/surefire-reports/EJB40/</reportsDirectory>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>
+

--- a/testenrichers/ejb-jakarta/src/main/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricher.java
+++ b/testenrichers/ejb-jakarta/src/main/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricher.java
@@ -1,0 +1,306 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.ejb;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.logging.Logger;
+import jakarta.ejb.EJB;
+import javax.naming.Context;
+import javax.naming.NamingException;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.spi.Validate;
+import org.jboss.arquillian.test.spi.TestEnricher;
+
+/**
+ * Enricher that provide EJB class and setter method injection.
+ *
+ * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class EJBInjectionEnricher implements TestEnricher {
+    private static final String ANNOTATION_NAME = "jakarta.ejb.EJB";
+
+    private static final Logger log = Logger.getLogger(TestEnricher.class.getName());
+
+    @Inject
+    private Instance<Context> contextInst;
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.arquillian.spi.TestEnricher#enrich(org.jboss.arquillian.spi .Context, java.lang.Object)
+     */
+    public void enrich(Object testCase) {
+        if (SecurityActions.isClassPresent(ANNOTATION_NAME)) {
+            try {
+                if (createContext() != null) {
+                    injectClass(testCase);
+                }
+            } catch (Exception e) {
+                log.throwing(EJBInjectionEnricher.class.getName(), "enrich", e);
+            }
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.arquillian.spi.TestEnricher#resolve(org.jboss.arquillian.spi .Context, java.lang.reflect.Method)
+     */
+    public Object[] resolve(Method method) {
+        return new Object[method.getParameterTypes().length];
+    }
+
+    /**
+     * Obtains all field in the specified class which contain the specified annotation
+     *
+     * @throws IllegalArgumentException
+     *     If either argument is not specified
+     */
+    // TODO Hack, this leaks out privileged operations outside the package. Extract out properly.
+    protected List<Field> getFieldsWithAnnotation(final Class<?> clazz, final Class<? extends Annotation> annotation)
+        throws IllegalArgumentException {
+        // Precondition checks
+        if (clazz == null) {
+            throw new IllegalArgumentException("clazz must be specified");
+        }
+        if (annotation == null) {
+            throw new IllegalArgumentException("annotation must be specified");
+        }
+
+        // Delegate to the privileged operations
+        return SecurityActions.getFieldsWithAnnotation(clazz, annotation);
+    }
+
+    protected void injectClass(Object testCase) {
+        try {
+            @SuppressWarnings("unchecked")
+            Class<? extends Annotation> ejbAnnotation =
+                (Class<? extends Annotation>) SecurityActions.getThreadContextClassLoader().loadClass(ANNOTATION_NAME);
+
+            List<Field> annotatedFields = SecurityActions.getFieldsWithAnnotation(
+                testCase.getClass(),
+                ejbAnnotation);
+
+            for (Field field : annotatedFields) {
+                if (field.get(testCase) == null) // only try to lookup fields that are not already set
+                {
+                    EJB fieldAnnotation = (EJB) field.getAnnotation(ejbAnnotation);
+                    try {
+                        String mappedName = fieldAnnotation.mappedName();
+                        ;
+                        String beanName = fieldAnnotation.beanName();
+                        String lookup = attemptToGet31LookupField(fieldAnnotation);
+
+                        String[] jndiNames = resolveJNDINames(field.getType(), mappedName, beanName, lookup);
+                        Object ejb = lookupEJB(jndiNames);
+                        field.set(testCase, ejb);
+                    } catch (Exception e) {
+                        log.fine("Could not lookup " + fieldAnnotation + ", other Enrichers might, move on. Exception: "
+                            + e.getMessage());
+                    }
+                }
+            }
+
+            List<Method> methods = SecurityActions.getMethodsWithAnnotation(testCase.getClass(), ejbAnnotation);
+
+            for (Method method : methods) {
+                if (method.getParameterTypes().length != 1) {
+                    throw new RuntimeException("@EJB only allowed on single argument methods");
+                }
+                if (!method.getName().startsWith("set")) {
+                    throw new RuntimeException("@EJB only allowed on 'set' methods");
+                }
+                EJB parameterAnnotation = null; // method.getParameterAnnotations()[0]
+                for (Annotation annotation : method.getParameterAnnotations()[0]) {
+                    if (EJB.class.isAssignableFrom(annotation.annotationType())) {
+                        parameterAnnotation = (EJB) annotation;
+                    }
+                }
+
+                // Default values of the annotation attributes.
+                String mappedName = null;
+                String beanName = null;
+                String lookup = null;
+
+                if (parameterAnnotation != null) {
+                    mappedName = parameterAnnotation.mappedName();
+                    beanName = parameterAnnotation.beanName();
+                    lookup = attemptToGet31LookupField(parameterAnnotation);
+                }
+
+                String[] jndiNames = resolveJNDINames(method.getParameterTypes()[0], mappedName, beanName, lookup);
+                Object ejb = lookupEJB(jndiNames);
+                method.invoke(testCase, ejb);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Could not inject members", e);
+        }
+    }
+
+    protected String attemptToGet31LookupField(EJB annotation) throws IllegalAccessException,
+        InvocationTargetException {
+        String lookup = null;
+        try {
+            Method m = EJB.class.getMethod("lookup");
+            lookup = String.valueOf(m.invoke(annotation));
+        } catch (NoSuchMethodException e) {
+            // No op, running on < 3.1 EJB lib
+        }
+        return lookup;
+    }
+
+    /**
+     * Resolves the JNDI name of the given field.
+     * <p>
+     * If <tt>mappedName</tt>, <tt>lookup</tt> or <tt>beanName</tt> are specified, they're used to resolve JNDI name.
+     * Otherwise, default policy
+     * applies.
+     * <p>
+     * If more than one of the <tt>mappedName</tt>, <tt>lookup</tt> and <tt>beanName</tt> {@link EJB} annotation
+     * attributes is specified at the same time, an {@link IllegalStateException}
+     * will be thrown.
+     *
+     * @param fieldType
+     *     annotated field which JNDI name should be resolved.
+     * @param mappedName
+     *     Value of {@link EJB}'s <tt>mappedName</tt> attribute.
+     * @param beanName
+     *     Value of {@link EJB}'s <tt>beanName</tt> attribute.
+     * @param lookup
+     *     Value of {@link EJB}'s <tt>lookup</tt> attribute.
+     *
+     * @return possible JNDI names which should be looked up to access the proper object.
+     */
+    protected String[] resolveJNDINames(Class<?> fieldType, String mappedName, String beanName, String lookup) {
+
+        MessageFormat msg = new MessageFormat(
+            "Trying to resolve JNDI name for field \"{0}\" with mappedName=\"{1}\" and beanName=\"{2}\"");
+        log.finer(msg.format(new Object[] {fieldType, mappedName, beanName}));
+
+        Validate.notNull(fieldType, "EJB enriched field cannot to be null.");
+
+        boolean isMappedNameSet = hasValue(mappedName);
+        boolean isBeanNameSet = hasValue(beanName);
+        boolean isLookupSet = hasValue(lookup);
+
+        if (isMoreThanOneValueTrue(isMappedNameSet, isBeanNameSet, isLookupSet)) {
+            throw new IllegalStateException(
+                "Only one of the @EJB annotation attributes 'mappedName', 'lookup' and 'beanName' can be specified at the same time.");
+        }
+
+        String[] jndiNames;
+
+        // If set, use only mapped name or bean name to lookup the EJB.
+        if (isMappedNameSet) {
+            jndiNames = new String[] {mappedName};
+        } else if (isLookupSet) {
+            jndiNames = new String[] {lookup};
+        } else if (isBeanNameSet) {
+            jndiNames = new String[] {"java:module/" + beanName + "!" + fieldType.getName()};
+        } else {
+            jndiNames = getJndiNamesForAnonymousEJB(fieldType);
+        }
+        return jndiNames;
+    }
+
+    protected String[] getJndiNamesForAnonymousEJB(Class<?> fieldType) {
+        String[] jndiNames;
+        // TODO: These names are not spec compliant; fieldType needs to be a bean type here, but usually is just an interface of a bean. These seldom work.
+        jndiNames = new String[] {
+            "java:global/test.ear/test/" + fieldType.getSimpleName() + "Bean",
+            "java:global/test.ear/test/" + fieldType.getSimpleName(),
+            "java:global/test/" + fieldType.getSimpleName(),
+            "java:global/test/" + fieldType.getSimpleName() + "Bean",
+            "java:global/test/" + fieldType.getSimpleName() + "/no-interface",
+            "java:module/" + fieldType.getSimpleName(),
+            "test/" + fieldType.getSimpleName() + "Bean/local",
+            "test/" + fieldType.getSimpleName() + "Bean/remote",
+            "test/" + fieldType.getSimpleName() + "/no-interface",
+            fieldType.getSimpleName() + "Bean/local",
+            fieldType.getSimpleName() + "Bean/remote",
+            fieldType.getSimpleName() + "/no-interface",
+            // WebSphere Application Server Local EJB default binding
+            "ejblocal:" + fieldType.getCanonicalName(),
+            // WebSphere Application Server Remote EJB default binding
+            fieldType.getCanonicalName()};
+        return jndiNames;
+    }
+
+    protected Object lookupEJB(String[] jndiNames) throws Exception {
+        // TODO: figure out test context ?
+        Context initcontext = createContext();
+
+        for (String jndiName : jndiNames) {
+            try {
+                return initcontext.lookup(jndiName);
+            } catch (NamingException e) {
+                // no-op, try next
+            }
+        }
+        throw new NamingException("No EJB found in JNDI, tried the following names: " + joinJndiNames(jndiNames));
+    }
+
+    protected Context createContext() throws Exception {
+        return contextInst.get();
+    }
+
+    // Simple helper for printing the jndi names
+    private String joinJndiNames(String[] strings) {
+        StringBuilder sb = new StringBuilder();
+
+        for (String string : strings) {
+            sb.append(string).append(", ");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Helper method that checks if the given String has a non-empty value.
+     *
+     * @param string
+     *     String to be checked.
+     *
+     * @return true if <tt>string</tt> is not null and has non-empty value; false otherwise.
+     */
+    private boolean hasValue(String string) {
+        if (string != null && (!string.trim().equals(""))) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private boolean isMoreThanOneValueTrue(boolean... values) {
+        boolean trueFound = false;
+        for (boolean value : values) {
+            if (value) {
+                if (trueFound) {
+                    return true;
+                }
+                trueFound = true;
+            }
+        }
+        return false;
+    }
+}

--- a/testenrichers/ejb-jakarta/src/main/java/org/jboss/arquillian/testenricher/ejb/SecurityActions.java
+++ b/testenrichers/ejb-jakarta/src/main/java/org/jboss/arquillian/testenricher/ejb/SecurityActions.java
@@ -1,0 +1,337 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.ejb;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A set of privileged actions that are not to leak out
+ * of this package
+ *
+ * @version $Revision: $
+ */
+final class SecurityActions {
+
+    //-------------------------------------------------------------------------------||
+    // Constructor ------------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * No instantiation
+     */
+    private SecurityActions() {
+        throw new UnsupportedOperationException("No instantiation");
+    }
+
+    //-------------------------------------------------------------------------------||
+    // Utility Methods --------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * Obtains the Thread Context ClassLoader
+     */
+    static ClassLoader getThreadContextClassLoader() {
+        return AccessController.doPrivileged(GetTcclAction.INSTANCE);
+    }
+
+    static boolean isClassPresent(String name) {
+        try {
+            loadClass(name);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    static Class<?> loadClass(String className) {
+        try {
+            return Class.forName(className, true, getThreadContextClassLoader());
+        } catch (ClassNotFoundException e) {
+            try {
+                return Class.forName(className, true, SecurityActions.class.getClassLoader());
+            } catch (ClassNotFoundException e2) {
+                throw new RuntimeException("Could not load class " + className, e2);
+            }
+        }
+    }
+
+    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments,
+        final Class<T> expectedType) {
+        @SuppressWarnings("unchecked")
+        Class<T> implClass = (Class<T>) loadClass(className);
+        if (!expectedType.isAssignableFrom(implClass)) {
+            throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+        }
+        return newInstance(implClass, argumentTypes, arguments);
+    }
+
+    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments,
+        final Class<T> expectedType, ClassLoader classLoader) {
+        Class<?> clazz = null;
+        try {
+            clazz = Class.forName(className, false, classLoader);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not load class " + className, e);
+        }
+        Object obj = newInstance(clazz, argumentTypes, arguments);
+        try {
+            return expectedType.cast(obj);
+        } catch (Exception e) {
+            throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType, e);
+        }
+    }
+
+    /**
+     * Create a new instance by finding a constructor that matches the argumentTypes signature
+     * using the arguments for instantiation.
+     *
+     * @param implClass
+     *     Full classname of class to create
+     * @param argumentTypes
+     *     The constructor argument types
+     * @param arguments
+     *     The constructor arguments
+     *
+     * @return a new instance
+     *
+     * @throws IllegalArgumentException
+     *     if className, argumentTypes, or arguments are null
+     * @throws RuntimeException
+     *     if any exceptions during creation
+     * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+     * @author <a href="mailto:andrew.rubinger@jboss.org">ALR</a>
+     */
+    static <T> T newInstance(final Class<T> implClass, final Class<?>[] argumentTypes, final Object[] arguments) {
+        if (implClass == null) {
+            throw new IllegalArgumentException("ImplClass must be specified");
+        }
+        if (argumentTypes == null) {
+            throw new IllegalArgumentException("ArgumentTypes must be specified. Use empty array if no arguments");
+        }
+        if (arguments == null) {
+            throw new IllegalArgumentException("Arguments must be specified. Use empty array if no arguments");
+        }
+        final T obj;
+        try {
+            Constructor<T> constructor = getConstructor(implClass, argumentTypes);
+            if (!constructor.isAccessible()) {
+                constructor.setAccessible(true);
+            }
+            obj = constructor.newInstance(arguments);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create new instance of " + implClass, e);
+        }
+
+        return obj;
+    }
+
+    /**
+     * Obtains the Constructor specified from the given Class and argument types
+     *
+     * @throws NoSuchMethodException
+     */
+    static <T> Constructor<T> getConstructor(final Class<T> clazz, final Class<?>... argumentTypes)
+        throws NoSuchMethodException {
+        try {
+            return AccessController.doPrivileged(new PrivilegedExceptionAction<Constructor<T>>() {
+                public Constructor<T> run() throws NoSuchMethodException {
+                    return clazz.getDeclaredConstructor(argumentTypes);
+                }
+            });
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof NoSuchMethodException) {
+                throw (NoSuchMethodException) t;
+            } else {
+                // No other checked Exception thrown by Class.getConstructor
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    /**
+     * Set a single Field value
+     *
+     * @param target
+     *     The object to set it on
+     * @param fieldName
+     *     The field name
+     * @param value
+     *     The new value
+     */
+    public static void setFieldValue(final Class<?> source, final Object target, final String fieldName,
+        final Object value) throws NoSuchFieldException {
+        try {
+            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
+                @Override
+                public Void run() throws Exception {
+                    Field field = source.getDeclaredField(fieldName);
+                    if (!field.isAccessible()) {
+                        field.setAccessible(true);
+                    }
+                    field.set(target, value);
+                    return null;
+                }
+            });
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof NoSuchFieldException) {
+                throw (NoSuchFieldException) t;
+            } else {
+                // No other checked Exception thrown by Class.getConstructor
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    public static List<Field> getFieldsWithAnnotation(final Class<?> source,
+        final Class<? extends Annotation> annotationClass) {
+        List<Field> declaredAccessableFields = AccessController.doPrivileged(new PrivilegedAction<List<Field>>() {
+            public List<Field> run() {
+                List<Field> foundFields = new ArrayList<Field>();
+                Class<?> nextSource = source;
+                while (nextSource != Object.class) {
+                    for (Field field : nextSource.getDeclaredFields()) {
+                        if (field.isAnnotationPresent(annotationClass)) {
+                            if (!field.isAccessible()) {
+                                field.setAccessible(true);
+                            }
+                            foundFields.add(field);
+                        }
+                    }
+                    nextSource = nextSource.getSuperclass();
+                }
+                return foundFields;
+            }
+        });
+        return declaredAccessableFields;
+    }
+
+    public static List<Method> getMethodsWithAnnotation(final Class<?> source,
+        final Class<? extends Annotation> annotationClass) {
+        List<Method> declaredAccessableMethods = AccessController.doPrivileged(new PrivilegedAction<List<Method>>() {
+            public List<Method> run() {
+                List<Method> foundMethods = new ArrayList<Method>();
+                Class<?> nextSource = source;
+                while (nextSource != Object.class) {
+                    for (Method method : filterBridgeMethods(nextSource.getDeclaredMethods())) {
+                        if (method.isAnnotationPresent(annotationClass)) {
+                            if (!method.isAccessible()) {
+                                method.setAccessible(true);
+                            }
+                            foundMethods.add(method);
+                        }
+                    }
+                    nextSource = nextSource.getSuperclass();
+                }
+                return foundMethods;
+            }
+        });
+        return declaredAccessableMethods;
+    }
+
+    static String getProperty(final String key) {
+        try {
+            String value = AccessController.doPrivileged(new PrivilegedExceptionAction<String>() {
+                public String run() {
+                    return System.getProperty(key);
+                }
+            });
+            return value;
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof SecurityException) {
+                throw (SecurityException) t;
+            }
+            if (t instanceof NullPointerException) {
+                throw (NullPointerException) t;
+            } else if (t instanceof IllegalArgumentException) {
+                throw (IllegalArgumentException) t;
+            } else {
+                // No other checked Exception thrown by System.getProtocolProperty
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    private static Collection<Method> filterBridgeMethods(Method... declaredMethods) {
+        final List<Method> nonBridgeMethods = new ArrayList<Method>(declaredMethods.length);
+
+        for (Method declaredMethod : declaredMethods) {
+            if (!declaredMethod.isBridge()) {
+                nonBridgeMethods.add(declaredMethod);
+            }
+        }
+
+        return nonBridgeMethods;
+    }
+
+    //-------------------------------------------------------------------------------||
+    // Inner Classes ----------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * Single instance to get the TCCL
+     */
+    private enum GetTcclAction implements PrivilegedAction<ClassLoader>
+
+    {
+        INSTANCE;
+
+        public ClassLoader run() {
+            return Thread.currentThread().getContextClassLoader();
+        }
+
+    }
+}

--- a/testenrichers/ejb-jakarta/src/main/java/org/jboss/arquillian/testenricher/ejb/client/EJBEnricherArchiveAppender.java
+++ b/testenrichers/ejb-jakarta/src/main/java/org/jboss/arquillian/testenricher/ejb/client/EJBEnricherArchiveAppender.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.ejb.client;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.container.test.spi.client.deployment.CachedAuxilliaryArchiveAppender;
+import org.jboss.arquillian.testenricher.ejb.EJBInjectionEnricher;
+import org.jboss.arquillian.testenricher.ejb.container.EJBEnricherRemoteExtension;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ * EJBEnricherArchiveAppender
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class EJBEnricherArchiveAppender extends CachedAuxilliaryArchiveAppender {
+    @Override
+    protected Archive<?> buildArchive() {
+        return ShrinkWrap.create(JavaArchive.class, "arquillian-testenricher-ejb-jakarta.jar")
+            .addPackage(EJBInjectionEnricher.class.getPackage())
+            .addClass(EJBEnricherRemoteExtension.class)
+            .addAsServiceProvider(RemoteLoadableExtension.class, EJBEnricherRemoteExtension.class);
+    }
+}

--- a/testenrichers/ejb-jakarta/src/main/java/org/jboss/arquillian/testenricher/ejb/client/EJBEnricherExtension.java
+++ b/testenrichers/ejb-jakarta/src/main/java/org/jboss/arquillian/testenricher/ejb/client/EJBEnricherExtension.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.ejb.client;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.TestEnricher;
+import org.jboss.arquillian.testenricher.ejb.EJBInjectionEnricher;
+
+/**
+ * EJBEnricherExtension
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class EJBEnricherExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(AuxiliaryArchiveAppender.class, EJBEnricherArchiveAppender.class);
+
+        // only load if EJB is on ClassPath
+        if (Validate.classExists("jakarta.ejb.EJB")) {
+            builder.service(TestEnricher.class, EJBInjectionEnricher.class);
+        }
+    }
+}

--- a/testenrichers/ejb-jakarta/src/main/java/org/jboss/arquillian/testenricher/ejb/container/EJBEnricherRemoteExtension.java
+++ b/testenrichers/ejb-jakarta/src/main/java/org/jboss/arquillian/testenricher/ejb/container/EJBEnricherRemoteExtension.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.ejb.container;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.test.spi.TestEnricher;
+import org.jboss.arquillian.testenricher.ejb.EJBInjectionEnricher;
+
+/**
+ * EJBEnricherRemoteExtension
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class EJBEnricherRemoteExtension implements RemoteLoadableExtension {
+    @Override
+    public void register(ExtensionBuilder builder) {
+        // only load if EJB is on ClassPath
+        if (Validate.classExists("jakarta.ejb.EJB")) {
+            builder.service(TestEnricher.class, EJBInjectionEnricher.class);
+        }
+    }
+}

--- a/testenrichers/ejb-jakarta/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/testenrichers/ejb-jakarta/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.arquillian.testenricher.ejb.client.EJBEnricherExtension

--- a/testenrichers/ejb-jakarta/src/test/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricher40TestCase.java
+++ b/testenrichers/ejb-jakarta/src/test/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricher40TestCase.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.ejb;
+
+import jakarta.ejb.EJB;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for {@link EJBInjectionEnricher}.
+ * <p>
+ * These tests doesn't use embedded container, as they're just simple unit tests.
+ *
+ * @author PedroKowalski
+ * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
+ */
+public class EJBInjectionEnricher40TestCase extends EJBInjectionEnricherBase {
+
+    @Test
+    public void testResolveJNDINameLookupSpecified() {
+        cut.enrich(new EJBEnrichedLookupClass());
+
+        String expected = EJBEnrichedLookupClass.class.getDeclaredFields()[0].getAnnotation(EJB.class).lookup();
+
+      /*
+       * When 'lookup' is set, the only JNDI name to check is the exact value specified in the annotation.
+       */
+        assertThat(resolvedJndiName, is(notNullValue()));
+        assertThat(resolvedJndiName.length, is(1));
+        assertThat(resolvedJndiName[0], is(expected));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowExceptionOnMappedNameAndLookup() {
+        cut.enrich(new EJBInvalidMappedNameAndLookupClass());
+
+        assertThat(caughtResolveException, notNullValue());
+        throw caughtResolveException;
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowExceptionOnBeanNameAndLookup() {
+        cut.enrich(new EJBInvalidBeanNameAndLookupClass());
+
+        assertThat(caughtResolveException, notNullValue());
+        throw caughtResolveException;
+    }
+
+    public static final class EJBEnrichedLookupClass {
+        @EJB(lookup = "java:global/org/arquillian/Test")
+        ExemplaryEJB lookupInjection;
+    }
+
+    public static final class EJBInvalidMappedNameAndLookupClass {
+        @EJB(mappedName = "any", lookup = "any")
+        ExemplaryEJB lookupInjection;
+    }
+
+    public static final class EJBInvalidBeanNameAndLookupClass {
+        @EJB(beanName = "any", lookup = "any")
+        ExemplaryEJB lookupInjection;
+    }
+}

--- a/testenrichers/ejb-jakarta/src/test/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricherBase.java
+++ b/testenrichers/ejb-jakarta/src/test/java/org/jboss/arquillian/testenricher/ejb/EJBInjectionEnricherBase.java
@@ -1,0 +1,103 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.ejb;
+
+import jakarta.ejb.EJB;
+import jakarta.ejb.Local;
+import jakarta.ejb.Stateless;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link EJBInjectionEnricher}.
+ * <p>
+ * These tests doesn't use embedded container, as they're just simple unit tests.
+ *
+ * @author PedroKowalski
+ */
+public class EJBInjectionEnricherBase {
+    protected EJBInjectionEnricher cut;
+
+    protected String[] resolvedJndiName;
+    protected RuntimeException caughtResolveException;
+
+    @Before
+    public void before() throws Exception {
+        cut = new EJBInjectionEnricher() {
+            @Override
+            protected Context createContext() throws Exception {
+                // just need to return non null. lookupEJB is overwritten so usage of context is under our control
+                return new InitialContext();
+            }
+
+            @Override
+            protected Object lookupEJB(String[] jndiNames) throws Exception {
+                resolvedJndiName = jndiNames;
+                return new ExemplaryEJBMockImpl();
+            }
+
+            @Override
+            protected String[] resolveJNDINames(Class<?> fieldType, String mappedName, String beanName, String lookup) {
+                try {
+                    return super.resolveJNDINames(fieldType, mappedName, beanName, lookup);
+                } catch (RuntimeException e) {
+                    caughtResolveException = e;
+                    throw e;
+                }
+            }
+        };
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testResolveJNDINameFieldNotSet() {
+        // Annotated field must be set.
+        cut.resolveJNDINames(null, "anyString()", null, null);
+    }
+
+    /**
+     * Exemplary EJB's local interface.
+     *
+     * @author PedroKowalski
+     */
+    @Local
+    public static interface ExemplaryEJB {
+    }
+
+    /**
+     * Exemplary implementation of the EJB's local interface.
+     *
+     * @author PedroKowalski
+     */
+    @Stateless
+    public static class ExemplaryEJBMockImpl implements ExemplaryEJB {
+    }
+
+    /**
+     * Exemplary implementation of the EJB's local interface.
+     * <p>
+     * This class is here only to be sure that despite more than one implementation of the interface, only the one pointed
+     * by
+     * <tt>beanName</tt> attribute of the {@link EJB} annotation will be used.
+     *
+     * @author PedroKowalski
+     */
+    @Stateless
+    public static class ExemplaryEJBProductionImpl implements ExemplaryEJB {
+    }
+}

--- a/testenrichers/pom.xml
+++ b/testenrichers/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- vi:ts=2:sw=2:expandtab: -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <!-- Parent -->
+  <parent>
+    <groupId>org.jboss.arquillian.jakarta</groupId>
+    <artifactId>arquillian-parent-jakarta</artifactId>
+    <version>1.8.1.Final-SNAPSHOT</version>
+  </parent>
+
+  <!-- Model Information -->
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Artifact Information -->
+  <groupId>org.jboss.arquillian.testenricher</groupId>
+  <artifactId>arquillian-testenricher-parent</artifactId>
+  <packaging>pom</packaging>
+  <name>Arquillian TestEnricher Aggregator</name>
+  <description>Arquillian TestEnricher Aggregator</description>
+
+  <modules>
+    <module>cdi-jakarta</module>
+    <module>ejb-jakarta</module>
+    <module>resource-jakarta</module>
+  </modules>
+</project>

--- a/testenrichers/resource-jakarta/pom.xml
+++ b/testenrichers/resource-jakarta/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <!-- Parent -->
+  <parent>
+    <groupId>org.jboss.arquillian.jakarta</groupId>
+    <artifactId>arquillian-parent-jakarta</artifactId>
+    <version>1.8.1.Final-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <!-- Model Version -->
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Artifact Configuration -->
+  <groupId>org.jboss.arquillian.testenricher</groupId>
+  <artifactId>arquillian-testenricher-resource-jakarta</artifactId>
+  <name>Arquillian TestEnricher Jakarta Resource</name>
+  <description>Jakarta Resource TestEnricher for the Arquillian Project</description>
+
+
+  <!-- Dependencies -->
+  <dependencies>
+
+    <!-- org.jboss.arquillian -->
+    <dependency>
+      <groupId>org.jboss.arquillian.test</groupId>
+      <artifactId>arquillian-test-spi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-spi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.shrinkwrap</groupId>
+      <artifactId>shrinkwrap-impl-base</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- External Projects -->
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+</project>
+

--- a/testenrichers/resource-jakarta/src/main/java/org/jboss/arquillian/testenricher/resource/ResourceInjectionEnricher.java
+++ b/testenrichers/resource-jakarta/src/main/java/org/jboss/arquillian/testenricher/resource/ResourceInjectionEnricher.java
@@ -1,0 +1,219 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.resource;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.logging.Logger;
+import jakarta.annotation.Resource;
+import javax.naming.Context;
+import javax.naming.NamingException;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.spi.TestEnricher;
+
+/**
+ * Enricher that provide @Resource field and method argument injection. <br/>
+ * <br/>
+ * Field Resources will only be injected if the current value is NULL or primitive default value.
+ *
+ * @author <a href="mailto:aknutsen@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ResourceInjectionEnricher implements TestEnricher {
+    private static final String RESOURCE_LOOKUP_PREFIX = "java:comp/env";
+    private static final String ANNOTATION_NAME = "jakarta.annotation.Resource";
+
+    private static final Logger log = Logger.getLogger(TestEnricher.class.getName());
+
+    @Inject
+    private Instance<Context> contextInst;
+
+    /* (non-Javadoc)
+     * @see org.jboss.arquillian.spi.TestEnricher#enrich(org.jboss.arquillian.spi.Context, java.lang.Object)
+     */
+    public void enrich(Object testCase) {
+        if (SecurityActions.isClassPresent(ANNOTATION_NAME) && contextInst.get() != null) {
+            injectClass(testCase);
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see org.jboss.arquillian.spi.TestEnricher#resolve(org.jboss.arquillian.spi.Context, java.lang.reflect.Method)
+     */
+    public Object[] resolve(Method method) {
+        return new Object[method.getParameterTypes().length];
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void injectClass(Object testCase) {
+        try {
+            ClassLoader classLoader = ResourceInjectionEnricher.class.getClassLoader();
+            Class<? extends Annotation> resourceAnnotation =
+                (Class<? extends Annotation>) classLoader.loadClass(ANNOTATION_NAME);
+
+            List<Field> annotatedFields = SecurityActions.getFieldsWithAnnotation(
+                testCase.getClass(),
+                resourceAnnotation);
+
+            for (Field field : annotatedFields) {
+            /*
+             * only try to lookup fields that are not already set or primitives
+             * (we don't really know if they have been set or not)
+             */
+                Object currentValue = field.get(testCase);
+                if (shouldInject(field, currentValue)) {
+                    try {
+                        Object resource = resolveResource(field);
+                        field.set(testCase, resource);
+                    } catch (Exception e) {
+                        log.fine("Could not lookup for "
+                            + field
+                            + ", other Enrichers might, move on. Exception: "
+                            + e.getMessage());
+                    }
+                }
+            }
+
+            List<Method> methods = SecurityActions.getMethodsWithAnnotation(
+                testCase.getClass(),
+                resourceAnnotation);
+
+            for (Method method : methods) {
+                if (method.getParameterTypes().length != 1) {
+                    throw new RuntimeException("@Resource only allowed on single argument methods");
+                }
+                if (!method.getName().startsWith("set")) {
+                    throw new RuntimeException("@Resource only allowed on 'set' methods");
+                }
+                Object resource = resolveResource(method);
+                method.invoke(testCase, resource);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Could not inject members", e);
+        }
+    }
+
+    /**
+     * Looks up the JNDI resource for any given annotated element.
+     *
+     * @param element
+     *     any annotated element (field, method, etc.)
+     *
+     * @return the located resource
+     *
+     * @throws Exception
+     */
+    protected Object resolveResource(AnnotatedElement element) throws Exception {
+        Object resolvedResource = null;
+        // This implementation is based on previous behavior in injectClass()
+        if (Field.class.isAssignableFrom(element.getClass())) {
+            resolvedResource = lookup(getResourceName((Field) element));
+        } else if (Method.class.isAssignableFrom(element.getClass())) {
+            resolvedResource = lookup(getResourceName(element.getAnnotation(Resource.class)));
+        }
+        return resolvedResource;
+    }
+
+    private boolean shouldInject(Field field, Object currentValue) {
+        Class<?> type = field.getType();
+        if (type.isPrimitive()) {
+            if (isPrimitiveNull(currentValue)) {
+                log.fine(
+                    "Primitive field " + field.getName() + " has been detected to have the default primitive value, " +
+                        "can not determine if it has already been injected. Re-injecting field.");
+                return true;
+            }
+        } else {
+            if (currentValue == null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isPrimitiveNull(Object currentValue) {
+        String stringValue = String.valueOf(currentValue);
+        if ("0".equals(stringValue) || "0.0".equals(stringValue) || "false".equals(stringValue)) {
+            return true;
+        } else if (Character.class.isInstance(currentValue)) {
+            if (Character.class.cast(currentValue) == (char) 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected Object lookup(String jndiName) throws Exception {
+        // TODO: figure out test context ?
+        Context context = getContainerContext();
+        return context.lookup(jndiName);
+    }
+
+    /**
+     * Obtains the appropriate context for the test.  Can be overriden by
+     * enrichers for each container to provide the correct context.
+     *
+     * @return the test context
+     *
+     * @throws NamingException
+     */
+    protected Context getContainerContext() throws NamingException {
+        return contextInst.get();
+    }
+
+    protected String getResourceName(Field field) {
+        Resource resource = field.getAnnotation(Resource.class);
+        String resourceName = getResourceName(resource);
+        if (resourceName != null) {
+            return resourceName;
+        }
+        String propertyName = field.getName();
+        String className = field.getDeclaringClass().getName();
+        return RESOURCE_LOOKUP_PREFIX + "/" + className + "/" + propertyName;
+    }
+
+    protected String getResourceName(Resource resource) {
+        String lookup = tryResourceLookup(resource);
+        if (!lookup.equals("")) {
+            return lookup;
+        }
+        String mappedName = resource.mappedName();
+        if (!mappedName.equals("")) {
+            return mappedName;
+        }
+        String name = resource.name();
+        if (!name.equals("")) {
+            return RESOURCE_LOOKUP_PREFIX + "/" + name;
+        }
+        return null;
+    }
+
+    protected String tryResourceLookup(Resource resource) {
+        try {
+            // added in Java EE 6 / Java SE 7
+            Method lookup = Resource.class.getDeclaredMethod("lookup");
+            return (String) lookup.invoke(resource);
+        } catch (Exception e) {
+            return "";
+        }
+    }
+}

--- a/testenrichers/resource-jakarta/src/main/java/org/jboss/arquillian/testenricher/resource/SecurityActions.java
+++ b/testenrichers/resource-jakarta/src/main/java/org/jboss/arquillian/testenricher/resource/SecurityActions.java
@@ -1,0 +1,337 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.resource;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A set of privileged actions that are not to leak out
+ * of this package
+ *
+ * @version $Revision: $
+ */
+final class SecurityActions {
+
+    //-------------------------------------------------------------------------------||
+    // Constructor ------------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * No instantiation
+     */
+    private SecurityActions() {
+        throw new UnsupportedOperationException("No instantiation");
+    }
+
+    //-------------------------------------------------------------------------------||
+    // Utility Methods --------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * Obtains the Thread Context ClassLoader
+     */
+    static ClassLoader getThreadContextClassLoader() {
+        return AccessController.doPrivileged(GetTcclAction.INSTANCE);
+    }
+
+    static boolean isClassPresent(String name) {
+        try {
+            loadClass(name);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    static Class<?> loadClass(String className) {
+        try {
+            return Class.forName(className, true, getThreadContextClassLoader());
+        } catch (ClassNotFoundException e) {
+            try {
+                return Class.forName(className, true, SecurityActions.class.getClassLoader());
+            } catch (ClassNotFoundException e2) {
+                throw new RuntimeException("Could not load class " + className, e2);
+            }
+        }
+    }
+
+    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments,
+        final Class<T> expectedType) {
+        @SuppressWarnings("unchecked")
+        Class<T> implClass = (Class<T>) loadClass(className);
+        if (!expectedType.isAssignableFrom(implClass)) {
+            throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType);
+        }
+        return newInstance(implClass, argumentTypes, arguments);
+    }
+
+    static <T> T newInstance(final String className, final Class<?>[] argumentTypes, final Object[] arguments,
+        final Class<T> expectedType, ClassLoader classLoader) {
+        Class<?> clazz = null;
+        try {
+            clazz = Class.forName(className, false, classLoader);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not load class " + className, e);
+        }
+        Object obj = newInstance(clazz, argumentTypes, arguments);
+        try {
+            return expectedType.cast(obj);
+        } catch (Exception e) {
+            throw new RuntimeException("Loaded class " + className + " is not of expected type " + expectedType, e);
+        }
+    }
+
+    /**
+     * Create a new instance by finding a constructor that matches the argumentTypes signature
+     * using the arguments for instantiation.
+     *
+     * @param implClass
+     *     Full classname of class to create
+     * @param argumentTypes
+     *     The constructor argument types
+     * @param arguments
+     *     The constructor arguments
+     *
+     * @return a new instance
+     *
+     * @throws IllegalArgumentException
+     *     if className, argumentTypes, or arguments are null
+     * @throws RuntimeException
+     *     if any exceptions during creation
+     * @author <a href="mailto:aslak@conduct.no">Aslak Knutsen</a>
+     * @author <a href="mailto:andrew.rubinger@jboss.org">ALR</a>
+     */
+    static <T> T newInstance(final Class<T> implClass, final Class<?>[] argumentTypes, final Object[] arguments) {
+        if (implClass == null) {
+            throw new IllegalArgumentException("ImplClass must be specified");
+        }
+        if (argumentTypes == null) {
+            throw new IllegalArgumentException("ArgumentTypes must be specified. Use empty array if no arguments");
+        }
+        if (arguments == null) {
+            throw new IllegalArgumentException("Arguments must be specified. Use empty array if no arguments");
+        }
+        final T obj;
+        try {
+            Constructor<T> constructor = getConstructor(implClass, argumentTypes);
+            if (!constructor.isAccessible()) {
+                constructor.setAccessible(true);
+            }
+            obj = constructor.newInstance(arguments);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create new instance of " + implClass, e);
+        }
+
+        return obj;
+    }
+
+    /**
+     * Obtains the Constructor specified from the given Class and argument types
+     *
+     * @throws NoSuchMethodException
+     */
+    static <T> Constructor<T> getConstructor(final Class<T> clazz, final Class<?>... argumentTypes)
+        throws NoSuchMethodException {
+        try {
+            return AccessController.doPrivileged(new PrivilegedExceptionAction<Constructor<T>>() {
+                public Constructor<T> run() throws NoSuchMethodException {
+                    return clazz.getDeclaredConstructor(argumentTypes);
+                }
+            });
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof NoSuchMethodException) {
+                throw (NoSuchMethodException) t;
+            } else {
+                // No other checked Exception thrown by Class.getConstructor
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    /**
+     * Set a single Field value
+     *
+     * @param target
+     *     The object to set it on
+     * @param fieldName
+     *     The field name
+     * @param value
+     *     The new value
+     */
+    public static void setFieldValue(final Class<?> source, final Object target, final String fieldName,
+        final Object value) throws NoSuchFieldException {
+        try {
+            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
+                @Override
+                public Void run() throws Exception {
+                    Field field = source.getDeclaredField(fieldName);
+                    if (!field.isAccessible()) {
+                        field.setAccessible(true);
+                    }
+                    field.set(target, value);
+                    return null;
+                }
+            });
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof NoSuchFieldException) {
+                throw (NoSuchFieldException) t;
+            } else {
+                // No other checked Exception thrown by Class.getConstructor
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    public static List<Field> getFieldsWithAnnotation(final Class<?> source,
+        final Class<? extends Annotation> annotationClass) {
+        List<Field> declaredAccessableFields = AccessController.doPrivileged(new PrivilegedAction<List<Field>>() {
+            public List<Field> run() {
+                List<Field> foundFields = new ArrayList<Field>();
+                Class<?> nextSource = source;
+                while (nextSource != Object.class) {
+                    for (Field field : nextSource.getDeclaredFields()) {
+                        if (field.isAnnotationPresent(annotationClass)) {
+                            if (!field.isAccessible()) {
+                                field.setAccessible(true);
+                            }
+                            foundFields.add(field);
+                        }
+                    }
+                    nextSource = nextSource.getSuperclass();
+                }
+                return foundFields;
+            }
+        });
+        return declaredAccessableFields;
+    }
+
+    public static List<Method> getMethodsWithAnnotation(final Class<?> source,
+        final Class<? extends Annotation> annotationClass) {
+        List<Method> declaredAccessableMethods = AccessController.doPrivileged(new PrivilegedAction<List<Method>>() {
+            public List<Method> run() {
+                List<Method> foundMethods = new ArrayList<Method>();
+                Class<?> nextSource = source;
+                while (nextSource != Object.class) {
+                    for (Method method : filterBridgeMethods(nextSource.getDeclaredMethods())) {
+                        if (method.isAnnotationPresent(annotationClass)) {
+                            if (!method.isAccessible()) {
+                                method.setAccessible(true);
+                            }
+                            foundMethods.add(method);
+                        }
+                    }
+                    nextSource = nextSource.getSuperclass();
+                }
+                return foundMethods;
+            }
+        });
+        return declaredAccessableMethods;
+    }
+
+    static String getProperty(final String key) {
+        try {
+            String value = AccessController.doPrivileged(new PrivilegedExceptionAction<String>() {
+                public String run() {
+                    return System.getProperty(key);
+                }
+            });
+            return value;
+        }
+        // Unwrap
+        catch (final PrivilegedActionException pae) {
+            final Throwable t = pae.getCause();
+            // Rethrow
+            if (t instanceof SecurityException) {
+                throw (SecurityException) t;
+            }
+            if (t instanceof NullPointerException) {
+                throw (NullPointerException) t;
+            } else if (t instanceof IllegalArgumentException) {
+                throw (IllegalArgumentException) t;
+            } else {
+                // No other checked Exception thrown by System.getProtocolProperty
+                try {
+                    throw (RuntimeException) t;
+                }
+                // Just in case we've really messed up
+                catch (final ClassCastException cce) {
+                    throw new RuntimeException("Obtained unchecked Exception; this code should never be reached", t);
+                }
+            }
+        }
+    }
+
+    private static Collection<Method> filterBridgeMethods(Method... declaredMethods) {
+        final List<Method> nonBridgeMethods = new ArrayList<Method>(declaredMethods.length);
+
+        for (Method declaredMethod : declaredMethods) {
+            if (!declaredMethod.isBridge()) {
+                nonBridgeMethods.add(declaredMethod);
+            }
+        }
+
+        return nonBridgeMethods;
+    }
+
+    //-------------------------------------------------------------------------------||
+    // Inner Classes ----------------------------------------------------------------||
+    //-------------------------------------------------------------------------------||
+
+    /**
+     * Single instance to get the TCCL
+     */
+    private enum GetTcclAction implements PrivilegedAction<ClassLoader>
+
+    {
+        INSTANCE;
+
+        public ClassLoader run() {
+            return Thread.currentThread().getContextClassLoader();
+        }
+
+    }
+}

--- a/testenrichers/resource-jakarta/src/main/java/org/jboss/arquillian/testenricher/resource/client/ResourceEnricherArchiveAppender.java
+++ b/testenrichers/resource-jakarta/src/main/java/org/jboss/arquillian/testenricher/resource/client/ResourceEnricherArchiveAppender.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.resource.client;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.container.test.spi.client.deployment.CachedAuxilliaryArchiveAppender;
+import org.jboss.arquillian.testenricher.resource.ResourceInjectionEnricher;
+import org.jboss.arquillian.testenricher.resource.container.ResourceEnricherRemoteExtension;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ * ResourceEnricherArchiveAppender
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ResourceEnricherArchiveAppender extends CachedAuxilliaryArchiveAppender {
+    @Override
+    protected Archive<?> buildArchive() {
+        return ShrinkWrap.create(JavaArchive.class, "arquillian-testenricher-resource-jakarta.jar")
+            .addPackage(ResourceInjectionEnricher.class.getPackage())
+            .addClass(ResourceEnricherRemoteExtension.class)
+            .addAsServiceProvider(RemoteLoadableExtension.class, ResourceEnricherRemoteExtension.class);
+    }
+}

--- a/testenrichers/resource-jakarta/src/main/java/org/jboss/arquillian/testenricher/resource/client/ResourceEnricherExtension.java
+++ b/testenrichers/resource-jakarta/src/main/java/org/jboss/arquillian/testenricher/resource/client/ResourceEnricherExtension.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.resource.client;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.TestEnricher;
+import org.jboss.arquillian.testenricher.resource.ResourceInjectionEnricher;
+
+/**
+ * ResourceEnricherExtension
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ResourceEnricherExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(AuxiliaryArchiveAppender.class, ResourceEnricherArchiveAppender.class);
+
+        // only load if Resource is on ClassPath
+        if (Validate.classExists("jakarta.annotation.Resource")) {
+            builder.service(TestEnricher.class, ResourceInjectionEnricher.class);
+        }
+    }
+}

--- a/testenrichers/resource-jakarta/src/main/java/org/jboss/arquillian/testenricher/resource/container/ResourceEnricherRemoteExtension.java
+++ b/testenrichers/resource-jakarta/src/main/java/org/jboss/arquillian/testenricher/resource/container/ResourceEnricherRemoteExtension.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.resource.container;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.test.spi.TestEnricher;
+import org.jboss.arquillian.testenricher.resource.ResourceInjectionEnricher;
+
+/**
+ * ResourceEnricherRemoteExtension
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ResourceEnricherRemoteExtension implements RemoteLoadableExtension {
+    @Override
+    public void register(ExtensionBuilder builder) {
+        // only load if Resource is on ClassPath
+        if (Validate.classExists("jakarta.annotation.Resource")) {
+            builder.service(TestEnricher.class, ResourceInjectionEnricher.class);
+        }
+    }
+}

--- a/testenrichers/resource-jakarta/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/testenrichers/resource-jakarta/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.arquillian.testenricher.resource.client.ResourceEnricherExtension

--- a/testenrichers/resource-jakarta/src/test/java/org/jboss/arquillian/testenricher/resource/ResourceInjectionEnricherTestCase.java
+++ b/testenrichers/resource-jakarta/src/test/java/org/jboss/arquillian/testenricher/resource/ResourceInjectionEnricherTestCase.java
@@ -1,0 +1,178 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat Inc. and/or its affiliates and other contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.testenricher.resource;
+
+import java.util.HashMap;
+import java.util.Map;
+import jakarta.annotation.Resource;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ResourceInjectionEnricherTestCase {
+    private final Map<String, Object> injectionValueMap = new HashMap<String, Object>();
+
+    {
+        injectionValueMap.put("primitive_char", '1');
+        injectionValueMap.put("primitive_byte", Byte.valueOf("1"));
+        injectionValueMap.put("primitive_int", 10);
+        injectionValueMap.put("primitive_short", (short) 10);
+        injectionValueMap.put("primitive_long", 10L);
+        injectionValueMap.put("primitive_float", 10f);
+        injectionValueMap.put("primitive_double", 10d);
+        injectionValueMap.put("primitive_boolean", true);
+        injectionValueMap.put("primitive_non_default_value", 120);
+
+        injectionValueMap.put("primitive", 100);
+        injectionValueMap.put("primitive2", 100);
+        injectionValueMap.put("object", this);
+        injectionValueMap.put("object2", this);
+    }
+
+    @Test
+    public void shouldInjectResourcesIntoObject() throws Exception {
+        InjectableTestClass testClass = new InjectableTestClass();
+
+        new ResourceInjectionEnricher() {
+            protected Object lookup(String jndiName) throws Exception {
+                return injectionValueMap.get(jndiName);
+            }
+
+            ;
+        }.injectClass(testClass);
+
+        Assert.assertEquals(
+            "Should be able to inject into primitive field",
+            injectionValueMap.get("primitive"),
+            testClass.getPrimitive());
+
+        Assert.assertEquals(
+            "Should be able to inject into primitive setter",
+            injectionValueMap.get("primitive2"),
+            testClass.getPrimitive2());
+
+        Assert.assertEquals(
+            "Should be able to inject into object field",
+            injectionValueMap.get("object"),
+            testClass.getObject());
+
+        Assert.assertEquals(
+            "Should be able to inject into object ssetter",
+            injectionValueMap.get("object2"),
+            testClass.getObject2());
+
+        Assert.assertEquals(
+            "Should inject primitive if it has default value",
+            injectionValueMap.get("primitive_char"),
+            testClass.primitive_char);
+
+        Assert.assertEquals(
+            "Should inject primitive if it has default value",
+            injectionValueMap.get("primitive_byte"),
+            testClass.primitive_byte);
+
+        Assert.assertEquals(
+            "Should inject primitive if it has default value",
+            injectionValueMap.get("primitive_int"),
+            testClass.primitive_int);
+
+        Assert.assertEquals(
+            "Should inject primitive if it has default value",
+            injectionValueMap.get("primitive_short"),
+            testClass.primitive_short);
+
+        Assert.assertEquals(
+            "Should inject primitive if it has default value",
+            injectionValueMap.get("primitive_long"),
+            testClass.primitive_long);
+
+        Assert.assertEquals(
+            "Should inject primitive if it has default value",
+            injectionValueMap.get("primitive_float"),
+            testClass.primitive_float);
+
+        Assert.assertEquals(
+            "Should inject primitive if it has default value",
+            injectionValueMap.get("primitive_double"),
+            testClass.primitive_double);
+
+        Assert.assertEquals(
+            "Should inject primitive if it has default value",
+            injectionValueMap.get("primitive_boolean"),
+            testClass.primitive_boolean);
+
+        Assert.assertNotSame(
+            "Should not inject primitive if it does not have default value",
+            injectionValueMap.get("primitive_non_default_value"),
+            testClass.primitive_non_default_value);
+    }
+
+    private static class InjectableTestClass {
+        @Resource(mappedName = "primitive_char")
+        public char primitive_char;
+        protected int primitive2;
+        @Resource(mappedName = "primitive_byte")
+        byte primitive_byte;
+        @Resource(mappedName = "primitive_int")
+        int primitive_int;
+        @Resource(mappedName = "primitive_short")
+        short primitive_short;
+        @Resource(mappedName = "primitive_long")
+        long primitive_long;
+        @Resource(mappedName = "primitive_float")
+        float primitive_float;
+        @Resource(mappedName = "primitive_double")
+        double primitive_double;
+        @Resource(mappedName = "primitive_boolean")
+        boolean primitive_boolean;
+        @Resource(mappedName = "primitive_non_default_value")
+        int primitive_non_default_value = 100;
+        @Resource(mappedName = "primitive")
+        private int primitive;
+        @Resource(mappedName = "object")
+        private Object object;
+
+        private Object object2;
+
+        public int getPrimitive() {
+            return primitive;
+        }
+
+        public int getPrimitive2() {
+            return primitive2;
+        }
+
+        @SuppressWarnings("unused")
+        @Resource(mappedName = "primitive")
+        public void setPrimitive2(int primitive2) {
+            this.primitive2 = primitive2;
+        }
+
+        public Object getObject() {
+            return object;
+        }
+
+        public Object getObject2() {
+            return object2;
+        }
+
+        @SuppressWarnings("unused")
+        @Resource(mappedName = "object")
+        public void setObject2(Object object2) {
+            this.object2 = object2;
+        }
+    }
+}


### PR DESCRIPTION
Add distributionManagement section
Add relativePath to parent pom
Move jakarta.* package based protocols and testenrichers to the arquillian-jakarta repo
Part 2 of https://github.com/arquillian/arquillian-core/issues/516